### PR TITLE
Fixed ordering and test cases to have predictable results

### DIFF
--- a/src/test/java/LimitFieldTest.java
+++ b/src/test/java/LimitFieldTest.java
@@ -26,9 +26,9 @@ public class LimitFieldTest extends AbstractFeatureServiceTest{
             .body("globalIdFieldName", is(""))
             .body("hasZ", is(false))
             .body("hasM", is(false))
-            
+
             .body("spatialReference.wkid", is(4326))
-            
+
             .body("fields.size()", is(3))
             .body("fields[0].name", is("OBJECTID"))
             .body("fields[0].type", is("esriFieldTypeOID"))
@@ -44,21 +44,23 @@ public class LimitFieldTest extends AbstractFeatureServiceTest{
             .body("fields[2].editable", is(false))
             .body("fields[2].nullable", is(true))
             .body("fields[2].domain", IsNull.nullValue())
-            
+
             .body("features.size()", is(20))
-            .body("features[0].attributes.OBJECTID", is(54322))
-            .body("features[0].attributes.name", is("Moldova"))
-            .body("features[0].attributes.domain", is("0372.ua"))
-            .body("features[0].geometry.x", is(29))
-            .body("features[0].geometry.y", is(47))
-            .body("features[19].attributes.OBJECTID", is(19093))
-            .body("features[19].attributes.name", is("Iraq"))
-            .body("features[19].attributes.domain", is("1080thefan.com"))
-            .body("features[19].geometry.x", is(44))
-            .body("features[19].geometry.y", is(33))
-            
+
+            .body("features[0].attributes.OBJECTID", is(1))
+            .body("features[0].attributes.name", is("United Kingdom"))
+            .body("features[0].attributes.domain", is("rtbf.be"))
+            .body("features[0].geometry.x", is(-2))
+            .body("features[0].geometry.y", is(54))
+
+            .body("features[19].attributes.OBJECTID", is(43))
+            .body("features[19].attributes.name", is("Greece"))
+            .body("features[19].attributes.domain", is("candianews.gr"))
+            .body("features[19].geometry.x", is(22))
+            .body("features[19].geometry.y", is(39))
+
             .body("exceededTransferLimit", is(false))
         ;
     }
-	
+
 }

--- a/src/test/java/OffsetAndLimitTest.java
+++ b/src/test/java/OffsetAndLimitTest.java
@@ -11,7 +11,7 @@ public class OffsetAndLimitTest extends AbstractFeatureServiceTest {
     public void testGkgOffsetAndLimit() {
 
         String path = request2path("gkgOffsetAndLimit.json");
-        
+
 
 
         RestAssured
@@ -28,9 +28,9 @@ public class OffsetAndLimitTest extends AbstractFeatureServiceTest {
             .body("globalIdFieldName", is(""))
             .body("hasZ", is(false))
             .body("hasM", is(false))
-            
+
             .body("spatialReference.wkid", is(4326))
-            
+
             .body("fields.size()", is(9))
             .body("fields[0].name", is("OBJECTID"))
             .body("fields[0].type", is("esriFieldTypeOID"))
@@ -46,10 +46,10 @@ public class OffsetAndLimitTest extends AbstractFeatureServiceTest {
             .body("fields[8].editable", is(false))
             .body("fields[8].nullable", is(true))
             .body("fields[8].domain", IsNull.nullValue())
-            
+
             .body("features.size()", is(10))
-            
-            .body("features[0].attributes.OBJECTID", is(3729))
+
+            .body("features[0].attributes.OBJECTID", is(3728))
             .body("features[0].attributes.urlpubtimedate", is(1495605600000L))
             .body("features[0].attributes.urlpubdate", is(1495584000000L))
             .body("features[0].attributes.url", is("http://www.ziuanews.ro/stiri/cozmin-gu-dovedirea-fraud-rii-alegerilor-din-2009-este-important-pentru-democra-ia-noastr-704622"))
@@ -58,19 +58,19 @@ public class OffsetAndLimitTest extends AbstractFeatureServiceTest {
             .body("features[0].attributes.domain", is("ziuanews.ro"))
             .body("features[0].attributes.urllangcode", is("ron"))
             .body("features[0].attributes.geores", is(1))
-            
-            .body("features[9].attributes.OBJECTID", is(25654))
+
+            .body("features[9].attributes.OBJECTID", is(25653))
             .body("features[9].attributes.urlpubtimedate", is(1495616400000L))
             .body("features[9].attributes.urlpubdate", is(1495584000000L))
             .body("features[9].attributes.url", is("http://www.zimbabwesituation.com/news/zimsit-m-govt-urged-to-export-transformers-to-raise-forex/"))
-            .body("features[9].attributes.name", is("Zambia"))
+            .body("features[9].attributes.name", is("Zimbabwe"))
             .body("features[9].attributes.urltone", is(-2.99f))
             .body("features[9].attributes.domain", is("zimbabwesituation.com"))
             .body("features[9].attributes.urllangcode", is("eng"))
             .body("features[9].attributes.geores", is(1))
-            
+
             .body("exceededTransferLimit", is(false))
         ;
     }
-	
+
 }

--- a/src/test/java/OrderByTest.java
+++ b/src/test/java/OrderByTest.java
@@ -6,12 +6,12 @@ import org.junit.Test;
 import io.restassured.RestAssured;
 
 public class OrderByTest extends AbstractFeatureServiceTest {
-	
+
 	@Test
     public void testGkgOrderbyTop10() {
 
         String path = request2path("gkgOrderbyTop10.json");
-        
+
 
         RestAssured
         .given()
@@ -27,9 +27,9 @@ public class OrderByTest extends AbstractFeatureServiceTest {
             .body("globalIdFieldName", is(""))
             .body("hasZ", is(false))
             .body("hasM", is(false))
-            
+
             .body("spatialReference.wkid", is(4326))
-            
+
             .body("fields.size()", is(9))
             .body("fields[0].name", is("OBJECTID"))
             .body("fields[0].type", is("esriFieldTypeOID"))
@@ -45,9 +45,9 @@ public class OrderByTest extends AbstractFeatureServiceTest {
             .body("fields[8].editable", is(false))
             .body("fields[8].nullable", is(true))
             .body("fields[8].domain", IsNull.nullValue())
-            
+
             .body("features.size()", is(10))
-            
+
             .body("features[0].attributes.OBJECTID", is(8991))
             .body("features[0].attributes.urlpubtimedate", is(1495605600000L))
             .body("features[0].attributes.urlpubdate", is(1495584000000L))
@@ -57,17 +57,17 @@ public class OrderByTest extends AbstractFeatureServiceTest {
             .body("features[0].attributes.domain", is("zz.diena.lv"))
             .body("features[0].attributes.urllangcode", is("lav"))
             .body("features[0].attributes.geores", is(1))
-            
-            .body("features[9].attributes.OBJECTID", is(9603))
-            .body("features[9].attributes.urlpubtimedate", is(1495605600000L))
+
+            .body("features[9].attributes.OBJECTID", is(31999))
+            .body("features[9].attributes.urlpubtimedate", is(1495623600000L))
             .body("features[9].attributes.urlpubdate", is(1495584000000L))
-            .body("features[9].attributes.url", is("http://zpravy.idnes.cz/platy-poslanci-senatori-prezident-2016-dwn-/domaci.aspx"))
-            .body("features[9].attributes.name", is("Czech Republic"))
-            .body("features[9].attributes.urltone", is(-1.78f))
+            .body("features[9].attributes.url", is("http://zpravy.idnes.cz/cholera-cesko-nakaza-0la-/domaci.aspx"))
+            .body("features[9].attributes.name", is("Ukraine"))
+            .body("features[9].attributes.urltone", is(-0.57f))
             .body("features[9].attributes.domain", is("zpravy.idnes.cz"))
             .body("features[9].attributes.urllangcode", is("ces"))
             .body("features[9].attributes.geores", is(1))
-            
+
             .body("exceededTransferLimit", is(false))
         ;
     }

--- a/src/test/resources/gkgLimitFields.json
+++ b/src/test/resources/gkgLimitFields.json
@@ -6,7 +6,7 @@
   },
   "query" : {
     "resultRecordCount" : 20,
-    "orderByFields": "domain ASC",
+    "orderByFields": "OBJECTID ASC",
     "outFields" : "domain,name,OBJECTID",
     "returnGeometry" : true
   }

--- a/src/test/resources/gkgObjectIds.json
+++ b/src/test/resources/gkgObjectIds.json
@@ -5,6 +5,7 @@
     "method" : "query"
   },
   "query" : {
-    "objectIds" : "56577,56576"
+    "objectIds" : "56577,56576",
+    "orderByFields": "OBJECTID DESC"
   }
 }

--- a/src/test/resources/gkgOffsetAndLimit.json
+++ b/src/test/resources/gkgOffsetAndLimit.json
@@ -7,6 +7,6 @@
   "query" : {
     "resultOffset" : 100,
     "resultRecordCount" : 10,
-    "orderByFields": "domain DESC"
+    "orderByFields": "domain DESC, OBJECTID ASC"
   }
 }

--- a/src/test/resources/gkgOrderbyTop10.json
+++ b/src/test/resources/gkgOrderbyTop10.json
@@ -6,6 +6,6 @@
 	},
 	"query" : {
 		"resultRecordCount" : 10,
-		"orderByFields": "domain DESC"
+		"orderByFields": "domain DESC, OBJECTID ASC"
 	}
 }

--- a/src/test/resources/gkgWhereIn.json
+++ b/src/test/resources/gkgWhereIn.json
@@ -6,6 +6,7 @@
   },
   "query" : {
     "where": "OBJECTID IN (56577, 56576)",
+    "orderByFields": "OBJECTID DESC",
     "returnCountOnly" : false
   }
 }


### PR DESCRIPTION
Some of the test cases didn't produce the same results run against different instances of the test data because ordering was not set for certain results.