### PR TITLE
Implemented a new feature to permit an "includeFields" in the Service…

### DIFF
--- a/config/test/services/GDeltGKG.json
+++ b/config/test/services/GDeltGKG.json
@@ -176,9 +176,33 @@
               "scalarType": "string",
               "alias": "doc_url"
             }
-          }
+          },
+          "includeFields": ["OBJECTID", "urlpubtimedate", "urlpubdate", "name", "url"]
         }
       ],
+      "readOnly": true
+    },
+    {
+      "id": 5,
+      "name" : "GKG level 4",
+      "decription": "GDelt GKG article data at geores 4 (city/landmark)",
+      "geometryType": "Polygon",
+      "idField": "OBJECTID",
+      "displayField": "name",
+      "geometryPath": "/geometry",
+      "extent" : {
+        "xmin" : -180,
+        "ymin" : -90,
+        "xmax" : 180,
+        "ymax" : 90,
+        "spatialReference" : {
+          "wkid" : 4326,
+          "latestWkid" : 4326
+        }
+      },
+      "schema": "GDeltGKG",
+      "view" : "Article",
+      "includeFields": ["OBJECTID", "urlpubtimedate", "urlpubdate", "name", "url"],
       "readOnly": true
     }
   ]

--- a/src/test/java/IncludeFieldsTest.java
+++ b/src/test/java/IncludeFieldsTest.java
@@ -1,0 +1,79 @@
+import io.restassured.RestAssured;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+
+public class IncludeFieldsTest extends AbstractFeatureServiceTest {
+
+    @Test
+    public void testIncludeFieldsInFirstDataSourcesObject() {
+        String path = "/marklogic/{service}/FeatureServer/{layer}/query?resultRecordCount={resultRecordCount}&orderByFields={orderByFields}&returnGeometry={returnGeometry}";
+                RestAssured
+                .given()
+                  .pathParam("service", "GDeltGKG")
+                  .pathParam("layer", 4)
+                  .pathParam("resultRecordCount", 5)
+                  .pathParam("orderByFields", "name&nbspASC")
+                  .pathParam("returnGeometry", true)
+
+                .when()
+                .log().uri()
+                .get(path)
+
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .log().ifValidationFails()
+
+                .body("features.size()", is(5))
+
+                .body("features[0].attributes.OBJECTID", is(20643))
+                .body("features[0].attributes.urlpubtimedate", is(1495616400000l))
+                .body("features[0].attributes.urlpubdate", is(1495584000000l))
+                .body("features[0].attributes.url", is("http://satnews.com/story.php?number=1191513746"))
+                .body("features[0].attributes.name", is("Aalborg, Nordjylland, Denmark"))
+
+                .body("features[0].attributes", not(hasKey("urltone")))
+                .body("features[0].attributes", not(hasKey("domain")))
+                .body("features[0].attributes", not(hasKey("urllangcode")))
+                .body("features[0].attributes", not(hasKey("geores")))
+        ;
+    }
+
+    @Test
+    public void testIncludeFieldsInOriginalSource() {
+        String path = "/marklogic/{service}/FeatureServer/{layer}/query?resultRecordCount={resultRecordCount}&orderByFields={orderByFields}&returnGeometry={returnGeometry}";
+        RestAssured
+                .given()
+                .pathParam("service", "GDeltGKG")
+                .pathParam("layer", 5)
+                .pathParam("resultRecordCount", 5)
+                .pathParam("orderByFields", "name&nbspASC")
+                .pathParam("returnGeometry", true)
+
+                .when()
+                .log().uri()
+                .get(path)
+
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .log().ifValidationFails()
+
+                .body("features.size()", is(5))
+
+                .body("features[0].attributes.OBJECTID", is(20643))
+                .body("features[0].attributes.urlpubtimedate", is(1495616400000l))
+                .body("features[0].attributes.urlpubdate", is(1495584000000l))
+                .body("features[0].attributes.url", is("http://satnews.com/story.php?number=1191513746"))
+                .body("features[0].attributes.name", is("Aalborg, Nordjylland, Denmark"))
+
+                .body("features[0].attributes", not(hasKey("urltone")))
+                .body("features[0].attributes", not(hasKey("domain")))
+                .body("features[0].attributes", not(hasKey("urllangcode")))
+                .body("features[0].attributes", not(hasKey("geores")))
+        ;
+    }
+}

--- a/src/test/java/ServiceDescriptorTest.java
+++ b/src/test/java/ServiceDescriptorTest.java
@@ -55,7 +55,7 @@ public class ServiceDescriptorTest extends AbstractFeatureServiceTest {
                 .body("units", is("esriDecimalDegrees"))
                 .body("syncEnabled", is(false))
 
-                .body("layers.size()", is(5))
+                .body("layers.size()", is(6))
                 .body("layers.name", hasItems("GKG level 1", "GKG level 2", "GKG level 3"))
             ;
 
@@ -118,7 +118,7 @@ public class ServiceDescriptorTest extends AbstractFeatureServiceTest {
                 .log().ifError()
                 .statusCode(200)
                 .log().ifValidationFails()
-                .body("layers.size()", is(5))
+                .body("layers.size()", is(6))
                 .body("layers.name", hasItems("GKG level 1", "GKG level 2", "GKG level 3","GKG level 4"))
             ;
 


### PR DESCRIPTION
… Descriptor. That element must be an array of strings. When it exists, Only the fields with names listed in the array are included in the results. That element can be included at the same JSON level as the "schema" & "view" elements either using or not using the "dataSources" array element.