### PR TITLE
Issue #13. Added time bounds to optic query

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Each layer in a service descriptor can include a _bounding query_. The bounding 
 Service descriptors and their layers can be programatically controlled so additional tools or user interfaces can create and control the descriptors on the fly, dynamically controlling the features that are displayed when ESRI tools access those layers.
 
 #### Views
-The Koop provider service uses MarkLogic views defined by TDE templates (technically it could use lexicon-based views as well but this hasn't been tested). Each layer in a service descriptor tells the Koop provider service which view to use when handling queries for that layer. 
+The Koop provider service uses MarkLogic views defined by TDE templates (technically it could use lexicon-based views as well but this hasn't been tested). Each layer in a service descriptor tells the Koop provider service which view to use when handling queries for that layer.
 
 #### Queries
 The Koop provider service uses the Optic API to process all queries. Esri Feature Service requests (see [the Feature Service API](https://resources.arcgis.com/en/help/rest/apiref/featureserver.html) for details) are either requests for service or layer metadata or queries against a specific layer. Queries are translated into CTS and Optic queries and handled by one of two pipelines: feature queries or aggregations.
@@ -152,7 +152,7 @@ Note: If you have existing views in your MarkLogic database, you may be able to 
 <a name="Install-with-Example"></a>
 ### Install the Example as a New Database
 If you would like to try out the connector using the included example database, follow these steps to install to the `example` database configuration. This will create an app server, modules database, and content and schemas databases called `esri-example-app-content` and `esri-example-app-schemas` respectively.
-> NOTE: The connector project uses ml-gradle so, technically, you could use the connector project to configure databases or other MarkLogic cluster configuration items but it is preferable to manage your overall MarkLogic configuration in a separate ml-gradle (or other tool) project. 
+> NOTE: The connector project uses ml-gradle so, technically, you could use the connector project to configure databases or other MarkLogic cluster configuration items but it is preferable to manage your overall MarkLogic configuration in a separate ml-gradle (or other tool) project.
 1) Edit the `gradle-example-app.properties` and set the MarkLogic port you would like to install the backend service on, your MarkLogic host name, username and password and what port you want the Koop server to run on.
     ```
     mlAppName=esri-example-app
@@ -200,7 +200,7 @@ If your environment and feature service configuration match one to one, you can 
 ### Build an Archive to Run in Disconnected Mode
 There are times when you may need to install the connector from a machine that is not connected to the internet. To support this, the gradle build supports a number of tasks you can use to build an archive that has all the dependencies packaged up that you can install from.
 
-> Note: You must build the deployer archive from a machine running the same OS as where you will run the install and the connector from. I.E. if you will be running the connector from a Linux machine, you will need to execute these steps on a Linux machine. 
+> Note: You must build the deployer archive from a machine running the same OS as where you will run the install and the connector from. I.E. if you will be running the connector from a Linux machine, you will need to execute these steps on a Linux machine.
 
 1) From a machine that has internet connectivity and is the same platform that you will be installing to, run `./gradlew buildMlDeployer`
 1) If successful, the `buildMlDeployer` task will have created the `build/MarkLogic-Esri-Connector.zip` zip file. The archive contains all of the dependencies needed to install and run the connector, including the node.js binaries and modules for the platform it was built on. The gradle properties in that zip file are set so installs from the archive will run in "disconnected" mode.
@@ -292,3 +292,13 @@ koopHost=koop.mydomain.com
 ```
 
 The MarkLogic server will use the value in `mlHost` if this property is not supplied.
+
+
+## Configuring Time Aware Feature Layers
+
+Time aware feature layers allow users to query specific time periods. ArcGIS supports this using a time slider. More info on configuring time settings in ArcGIS Online, https://doc.arcgis.com/en/arcgis-online/create-maps/configure-time.htm.  Time aware layers have additional configuration properties, primarily a start and end date. A sample of the layer configuration is included in config/test/services/GDeltGKG.json, layer 6.  You must have a dateTime property defined in your TDE.  The layer configuration will reference this property name.
+
+### Limitations (TODO in another release)
+- This implementation only works for a start date. The end date configured in the layer and in your TDE will be ignored.
+- This implementation assumes that all server side dates are in UTC, there are no time zone conversions. The time zone and daylight savings indicator configured in your layer will be ignored.
+- The time extent configured in the layer is ignored

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
     else {
         repositories {
-            maven { url "https://plugins.gradle.org/m2/" }
             jcenter()
+            maven { url "http://plugins.gradle.org/m2/" }
         }
 
         dependencies {
@@ -59,9 +59,9 @@ if (project.hasProperty("disconnected") && disconnected) {
  */
 else {
     repositories {
+        maven { url "http://developer.marklogic.com/maven2/" }
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "http://repository.cloudera.com/artifactory/cloudera-repos/" }
-        maven { url "https://developer.marklogic.com/maven2/" }
 
         jcenter()
     }
@@ -75,7 +75,8 @@ else {
     }
 
     dependencies {
-        mlcp "com.marklogic:mlcp:9.0.3"
+        //mlcp "com.marklogic:mlcp:9.0.3"
+        mlcp "com.marklogic:mlcp:9.0.8"
         mlcp "org.apache.commons:commons-csv:1.2"
         mlcp "com.marklogic:marklogic-mapreduce2:2.2.3"
         mlcp files("log")

--- a/config/test/services/GDeltGKG.json
+++ b/config/test/services/GDeltGKG.json
@@ -204,6 +204,62 @@
       "view" : "Article",
       "includeFields": ["OBJECTID", "urlpubtimedate", "urlpubdate", "name", "url"],
       "readOnly": true
+    },
+    {
+      "id": 6,
+      "name" : "GKG level 1 Time Aware",
+      "decription": "GDelt GKG article data at geores 1 (country) Time Aware",
+      "geometryType": "Point",
+      "idField": "OBJECTID",
+      "displayField": "name",
+      "geometryPath": "/geometry",
+      "extent" : {
+        "xmin" : -180,
+        "ymin" : -90,
+        "xmax" : 180,
+        "ymax" : 90,
+        "spatialReference" : {
+          "wkid" : 4326,
+          "latestWkid" : 4326
+        }
+      },
+      "timeInfo": {
+        "startTimeField": "urlpubtimedate",
+        "endTimeField": "",
+        "trackIdField": "",
+        "timeExtent": [
+          1546300800000,
+          1552694400000
+        ],
+        "timeReference": {
+          "timeZone": "UTC",
+          "respectsDaylightSaving": false
+        },
+        "timeInterval": 1,
+        "timeIntervalUnits": "esriTimeUnitsMonths",
+        "exportOptions": {
+          "useTime": false,
+          "timeDataCumulative": false,
+          "TimeOffset": 0,
+          "timeOffsetUnits": "esriTimeUnitsCenturies"
+        },
+        "hasLiveData": false
+      },
+      "schema": "GDeltGKG",
+      "view" : "Article",
+      "boundingQuery" : {
+        "jsonPropertyValueQuery" : {
+          "property" : ["geores"], "value" : [ 1 ],
+          "options" : ["lang=en"], "weight" : 0
+        }
+      },
+      "geometry" : {
+        "type" : "Point",
+        "format" : "geojson",
+        "coordinateSystem" : "wgs84",
+        "xpath" : "//geometry"
+      },
+      "readOnly": true
     }
   ]
 }

--- a/src/main/ml-modules/services/KoopProvider.sjs
+++ b/src/main/ml-modules/services/KoopProvider.sjs
@@ -704,6 +704,37 @@ function parseGroupByFields(query) {
   return fields;
 }
 
+/**
+ * Builds an optic where clause for the time bounds given
+ * the the layer model and req.
+ * @param {object} layerModel - the layer description json data
+ * @param {object} req - the request parameters passed into the service (json)
+ * @return {booleanExpression} result of optic expressions, input to op.where
+*/
+function getTimeBoundingWhereQuery(layerModel, req) {
+  let startTimeField = layerModel.timeInfo.startTimeField
+  let endTimeField = layerModel.timeInfo.endTimeField
+  let timeRange = req.query.time.split(",")
+  let startTime = new Date(parseInt(timeRange[0]))
+  let endTime = new Date(parseInt(timeRange[1]))
+
+  //Assume dates in ML documents are in UTC for now.
+  //Currently only handling startDate bounds.
+
+  //TODO implement bounds for start AND end time
+
+  //TODO get time zone info from layerModel.timeInfo.timeReference.timeZone
+  //  and convert time to TZ setting
+  //https://developers.arcgis.com/javascript/3/jsapi/timeinfo.html
+  let utcStartTime = new Date(Date.UTC(startTime.getFullYear(), startTime.getMonth(), startTime.getDate()))
+  let utcEndTime = new Date(Date.UTC(endTime.getFullYear(), endTime.getMonth(), endTime.getDate()))
+
+  return op.and(
+    op.ge(op.viewCol(layerModel.view, startTimeField), utcStartTime.toISOString()),
+    op.lt(op.viewCol(layerModel.view, startTimeField), utcEndTime.toISOString())
+  )
+}
+
 // returns a Sequence of documents
 function getObjects(req) {
   const layerModel = getLayerModel(req.params.id, req.params.layer);
@@ -747,6 +778,11 @@ function getObjects(req) {
     const idsQuery = (idExp.length === 1) ? idExp[0] : op.or(...idExp);
 
     whereQuery = op.and(whereQuery, idsQuery);
+  }
+
+  // Initial Time bounding query implementation, GitHub Issue #13
+  if(req.query.time && layerModel.timeInfo && layerModel.timeInfo.startTimeField) {
+    whereQuery = op.and(whereQuery, getTimeBoundingWhereQuery(layerModel, req));
   }
 
   const boundingQuery = cts.andQuery(boundingQueries);

--- a/src/main/ml-modules/services/KoopProvider.sjs
+++ b/src/main/ml-modules/services/KoopProvider.sjs
@@ -707,32 +707,39 @@ function parseGroupByFields(query) {
 /**
  * Builds an optic where clause for the time bounds given
  * the the layer model and req.
+ *
+ * Assume dates in ML documents are in UTC for now.
+ * Currently only handling startDate bounds.
+ *
+ * TODO implement bounds for start AND end time
+ * TODO get time zone info from layerModel.timeInfo.timeReference.timeZone
+ *  and convert time to TZ setting, https://developers.arcgis.com/javascript/3/jsapi/timeinfo.html
+
  * @param {object} layerModel - the layer description json data
  * @param {object} req - the request parameters passed into the service (json)
  * @return {booleanExpression} result of optic expressions, input to op.where
 */
 function getTimeBoundingWhereQuery(layerModel, req) {
-  let startTimeField = layerModel.timeInfo.startTimeField
-  let endTimeField = layerModel.timeInfo.endTimeField
-  let timeRange = req.query.time.split(",")
-  let startTime = new Date(parseInt(timeRange[0]))
-  let endTime = new Date(parseInt(timeRange[1]))
+  let startTimeField = layerModel.timeInfo.startTimeField;
+  let endTimeField = layerModel.timeInfo.endTimeField;
 
-  //Assume dates in ML documents are in UTC for now.
-  //Currently only handling startDate bounds.
+  if(req.query.time.toString().indexOf(",") >= 0) {  //Handle Time range
+    let timeRange = req.query.time.split(",");
+    let startTime = (timeRange[0]) ? new Date(parseInt(timeRange[0])) : new Date("0001-01-01T00:00:00");
+    let endTime = (timeRange[1]) ? new Date(parseInt(timeRange[1])) : new Date("9999-12-31T00:00:00");
+    let utcStartTime = new Date(Date.UTC(startTime.getFullYear(), startTime.getMonth(), startTime.getDate()));
+    let utcEndTime = new Date(Date.UTC(endTime.getFullYear(), endTime.getMonth(), endTime.getDate()));
 
-  //TODO implement bounds for start AND end time
+    return op.and(
+      op.ge(op.viewCol(layerModel.view, startTimeField), utcStartTime.toISOString()),
+      op.lt(op.viewCol(layerModel.view, startTimeField), utcEndTime.toISOString())
+    )
+  } else {  //Handle time instance
+    let startTime = new Date(parseInt(req.query.time));
+    let utcStartTime = new Date(Date.UTC(startTime.getFullYear(), startTime.getMonth(), startTime.getDate()));
 
-  //TODO get time zone info from layerModel.timeInfo.timeReference.timeZone
-  //  and convert time to TZ setting
-  //https://developers.arcgis.com/javascript/3/jsapi/timeinfo.html
-  let utcStartTime = new Date(Date.UTC(startTime.getFullYear(), startTime.getMonth(), startTime.getDate()))
-  let utcEndTime = new Date(Date.UTC(endTime.getFullYear(), endTime.getMonth(), endTime.getDate()))
-
-  return op.and(
-    op.ge(op.viewCol(layerModel.view, startTimeField), utcStartTime.toISOString()),
-    op.lt(op.viewCol(layerModel.view, startTimeField), utcEndTime.toISOString())
-  )
+    return op.eq(op.viewCol(layerModel.view, startTimeField), utcStartTime.toISOString());
+  }
 }
 
 // returns a Sequence of documents

--- a/src/test/java/TimeBoundTest.java
+++ b/src/test/java/TimeBoundTest.java
@@ -43,6 +43,128 @@ public class TimeBoundTest extends AbstractFeatureServiceTest {
         	assertTrue(item <= 1496275200000L);
 		}
     }
+	
+	//Support numeric parameters as described in https://doc.arcgis.com/en/operations-dashboard/help/url-parameters.htm
+	@Test
+    public void testTimeBoundLeftOpen() {
+
+        String path = request2path("gkgTimeBoundLeftOpen.json");
+
+        //RestAssured
+        Response response = 
+        //.given()
+        RestAssured.given()
+        .when()
+            .log().uri()
+            .get(path)
+
+        .then()
+            .log().ifError()
+            .statusCode(200)
+            .log().ifValidationFails()
+            .extract().response()
+        ;
+        
+        List<Long> jsonResponse = response.jsonPath().getList("features.attributes.urlpubtimedate");
+        
+        //Assert that each feature returned is within the time bounds
+        for (Long item : jsonResponse) {
+        	if(item > 1496275200000L) {
+				System.out.println(item + " is NOT less than 1496275200000L");
+			}
+        	
+        	assertTrue(item <= 1496275200000L);
+		}
+    }
+	
+	@Test
+    public void testTimeBoundRightOpen() {
+
+        String path = request2path("gkgTimeBoundRightOpen.json");
+
+        //RestAssured
+        Response response = 
+        //.given()
+        RestAssured.given()
+        .when()
+            .log().uri()
+            .get(path)
+
+        .then()
+            .log().ifError()
+            .statusCode(200)
+            .log().ifValidationFails()
+            .extract().response()
+        ;
+        
+        List<Long> jsonResponse = response.jsonPath().getList("features.attributes.urlpubtimedate");
+        
+        //Assert that each feature returned is within the time bounds
+        for (Long item : jsonResponse) {
+        	if(item <= 1493596800000L) {
+				System.out.println(item + " is NOT greater than 1493596800000L");
+			}
+        	
+        	assertTrue(item >= 1493596800000L);
+		}
+    }
+	
+	@Test
+    public void testTimeBoundInstant() {
+
+        String path = request2path("gkgTimeBoundInstant.json");
+
+        //RestAssured
+        Response response = 
+        //.given()
+        RestAssured.given()
+        .when()
+            .log().uri()
+            .get(path)
+
+        .then()
+            .log().ifError()
+            .statusCode(200)
+            .log().ifValidationFails()
+            .extract().response()
+        ;
+        
+        List<Long> jsonResponse = response.jsonPath().getList("features.attributes.urlpubtimedate");
+        
+        //Assert that each feature returned is within the time bounds
+        for (Long item : jsonResponse) {
+        	if(item != 1495616400000L) {
+				System.out.println(item + " is NOT equal to 1493596800000L");
+			}
+        	
+        	assertTrue(item == 1495616400000L);
+		}
+    }
+	
+	@Test
+    public void testTimeBoundNull() {
+
+        String path = request2path("gkgTimeBoundNull.json");
+
+        //RestAssured
+        Response response = 
+        //.given()
+        RestAssured.given()
+        .when()
+            .log().uri()
+            .get(path)
+
+        .then()
+            .log().ifError()
+            .statusCode(200)
+            .log().ifValidationFails()
+            .extract().response()
+        ;
+        
+        List<Long> jsonResponse = response.jsonPath().getList("features.attributes.urlpubtimedate");
+        
+        assertTrue(jsonResponse.size() >= 20);
+    }
 }
 
 //"24457","24973","5632","24974","27161","56371","49518","49416","32295","32309","32296","47923","32293","8384","44483","32724","22445","22455","1807","5538"

--- a/src/test/java/TimeBoundTest.java
+++ b/src/test/java/TimeBoundTest.java
@@ -1,0 +1,48 @@
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+
+
+public class TimeBoundTest extends AbstractFeatureServiceTest {
+
+	@Test
+    public void testTimeBound() {
+
+        String path = request2path("gkgTimeBound.json");
+
+        //RestAssured
+        Response response = 
+        //.given()
+        RestAssured.given()
+        .when()
+            .log().uri()
+            .get(path)
+
+        .then()
+            .log().ifError()
+            .statusCode(200)
+            .log().ifValidationFails()
+            .extract().response()
+        ;
+        
+        List<Long> jsonResponse = response.jsonPath().getList("features.attributes.urlpubtimedate");
+        
+        //Assert that each feature returned is within the time bounds
+        for (Long item : jsonResponse) {
+        	if(item < 1493596800000L || item > 1496275200000L) {
+				System.out.println(item + " is NOT between 1493596800000L and 1496275200000L");
+			}
+        	
+        	assertTrue(item >= 1493596800000L);
+        	assertTrue(item <= 1496275200000L);
+		}
+    }
+}
+
+//"24457","24973","5632","24974","27161","56371","49518","49416","32295","32309","32296","47923","32293","8384","44483","32724","22445","22455","1807","5538"

--- a/src/test/resources/gkgTimeBound.json
+++ b/src/test/resources/gkgTimeBound.json
@@ -1,0 +1,12 @@
+{
+  "params" : {
+    "id" : "GDeltGKG",
+    "layer" : 6,
+    "method" : "query"
+  },
+  "query" : {
+  	"time" : "1493596800000,1496275200000",
+    "resultRecordCount" : 20,
+    "returnIdsOnly" : false
+  }
+}

--- a/src/test/resources/gkgTimeBoundInstant.json
+++ b/src/test/resources/gkgTimeBoundInstant.json
@@ -1,0 +1,12 @@
+{
+  "params" : {
+    "id" : "GDeltGKG",
+    "layer" : 6,
+    "method" : "query"
+  },
+  "query" : {
+  	"time" : "1493596800000",
+    "resultRecordCount" : 20,
+    "returnIdsOnly" : false
+  }
+}

--- a/src/test/resources/gkgTimeBoundLeftOpen.json
+++ b/src/test/resources/gkgTimeBoundLeftOpen.json
@@ -1,0 +1,12 @@
+{
+  "params" : {
+    "id" : "GDeltGKG",
+    "layer" : 6,
+    "method" : "query"
+  },
+  "query" : {
+  	"time" : ",1496275200000",
+    "resultRecordCount" : 20,
+    "returnIdsOnly" : false
+  }
+}

--- a/src/test/resources/gkgTimeBoundNull.json
+++ b/src/test/resources/gkgTimeBoundNull.json
@@ -1,0 +1,12 @@
+{
+  "params" : {
+    "id" : "GDeltGKG",
+    "layer" : 6,
+    "method" : "query"
+  },
+  "query" : {
+  	"time" : "",
+    "resultRecordCount" : 20,
+    "returnIdsOnly" : false
+  }
+}

--- a/src/test/resources/gkgTimeBoundRightOpen.json
+++ b/src/test/resources/gkgTimeBoundRightOpen.json
@@ -1,0 +1,12 @@
+{
+  "params" : {
+    "id" : "GDeltGKG",
+    "layer" : 6,
+    "method" : "query"
+  },
+  "query" : {
+  	"time" : "1493596800000,",
+    "resultRecordCount" : 20,
+    "returnIdsOnly" : false
+  }
+}


### PR DESCRIPTION
Implementation of the time bounding query.  This implementation updates the optic query, not the bounding (cts) query.  There is an existing branch, "feature/13" that implements the logic for the bounding cts query.  You may want to merge this branch as well so that you can have the option of optic and cts bounding queries.

I also updated the plugin urls since they have changed.  I had to do this to get it to build.
@jkerr5