### PR TITLE
Added basePath method to remove duplication of URL base path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,7 @@ gradle-app.setting
 package-lock.json
 test/bin/
 bin/
+test/out
 
 # Intellij
 .idea

--- a/test/src/test/java/AliasTest.java
+++ b/test/src/test/java/AliasTest.java
@@ -1,5 +1,4 @@
 import io.restassured.RestAssured;
-import org.hamcrest.core.IsNull;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -9,7 +8,7 @@ public class AliasTest extends AbstractFeatureServiceTest {
 
     @Test
     public void testFieldAlias() {
-        String path = "/marklogic/{service}/FeatureServer/{layer}/query?resultRecordCount={resultRecordCount}&orderByFields={orderByFields}&returnGeometry={returnGeometry}";
+        String path = basePath("{service}") + "/FeatureServer/{layer}/query?resultRecordCount={resultRecordCount}&orderByFields={orderByFields}&returnGeometry={returnGeometry}";
                 RestAssured
                 .given()
                   .pathParam("service", "GDeltGKG")

--- a/test/src/test/java/AnyQueries.java
+++ b/test/src/test/java/AnyQueries.java
@@ -3,7 +3,6 @@ import static org.hamcrest.Matchers.*;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import org.hamcrest.core.IsNull;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -14,10 +13,10 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
 	@Test
     public void testAnyPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -33,14 +32,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))
             ;
 		}
-	
+
 	@Test
     public void testAnyGeometryPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -58,14 +57,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
                 ;
 		}
-	
+
 	@Test
     public void testAnyPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -81,14 +80,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
             ;
 		}
-	
+
 	@Test
     public void testAnyGeometryPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -102,18 +101,18 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}
-	
+
 	@Test
     public void testAnyPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -129,14 +128,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testAnyGeometryPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -150,18 +149,18 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testAnyPolygon4() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[74.81689453125,24.666986385216273],[76.6845703125,24.666986385216273],[76.6845703125,25.64152637306577],[74.81689453125,25.64152637306577],[74.81689453125,24.666986385216273]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -176,14 +175,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testAnyPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -199,14 +198,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
-	
+
 	@Test
     public void testAnyGeometryPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -220,18 +219,18 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
 
-	// Envelope Test cases 
+	// Envelope Test cases
 	@Test
     public void testAnyEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -246,13 +245,13 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(14))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))            ;
 	   }
-	
+
 	@Test
     public void testAnyGeometryEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -270,13 +269,13 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
             ;
 	   }
-	
+
 	@Test
     public void testAnyEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -288,17 +287,17 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(17))     
+                .body("features.size()", is(17))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testAnyGeometryEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -312,17 +311,17 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testAnyEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -334,17 +333,17 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(5))    
+                .body("features.size()", is(5))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 	@Test
     public void testAnyGeometryEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -358,18 +357,18 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 
 	@Test
     public void testAnyEnvelope4() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -381,16 +380,16 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(0))    
+                .body("features.size()", is(0))
             ;
 	   }
-	
+
 	@Test
     public void testAnyEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -406,13 +405,13 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
                 ;
 	   }
-	
+
 	@Test
     public void testAnyGeometryEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -426,18 +425,18 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"));
 	   }
-	
+
 	//Point test cases
 	@Test
     public void testAnyPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -453,14 +452,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testAnyGeometryPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -474,18 +473,18 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testAnyPoint2() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 92.46093749999999, \"y\" : 39.095962936305476}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -500,14 +499,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testAnyPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -523,14 +522,14 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testAnyGeometryPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -544,17 +543,17 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testAnyAllFields() throws UnsupportedEncodingException, ParseException  {
 
 		String path = "marklogic/GeoLocation/FeatureServer/{layer}/query?outFields=*";
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 5)
@@ -566,7 +565,7 @@ public class AnyQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}

--- a/test/src/test/java/CustomQueries.java
+++ b/test/src/test/java/CustomQueries.java
@@ -3,7 +3,6 @@ import static org.hamcrest.Matchers.*;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import org.hamcrest.core.IsNull;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -14,10 +13,10 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
 	@Test
     public void testCustomPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -33,14 +32,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))
             ;
 		}
-	
+
 	@Test
     public void testCustomGeometryPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -58,14 +57,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
                 ;
 		}
-	
+
 	@Test
     public void testCustomPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -81,14 +80,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
             ;
 		}
-	
+
 	@Test
     public void testCustomGeometryPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -102,18 +101,18 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}
-	
+
 	@Test
     public void testCustomPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -129,14 +128,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testCustomGeometryPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -150,18 +149,18 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testCustomPolygon4() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[74.81689453125,24.666986385216273],[76.6845703125,24.666986385216273],[76.6845703125,25.64152637306577],[74.81689453125,25.64152637306577],[74.81689453125,24.666986385216273]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -176,14 +175,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testCustomPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -199,14 +198,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
-	
+
 	@Test
     public void testCustomGeometryPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -220,18 +219,18 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
 
-	// Envelope Test cases 
+	// Envelope Test cases
 	@Test
     public void testCustomEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -246,13 +245,13 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(14))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))            ;
 	   }
-	
+
 	@Test
     public void testCustomGeometryEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -270,13 +269,13 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
             ;
 	   }
-	
+
 	@Test
     public void testCustomEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -288,17 +287,17 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(17))     
+                .body("features.size()", is(17))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testCustomGeometryEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -312,17 +311,17 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testCustomEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -334,17 +333,17 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(5))    
+                .body("features.size()", is(5))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 	@Test
     public void testCustomGeometryEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -358,18 +357,18 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 
 	@Test
     public void testCustomEnvelope4() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -381,16 +380,16 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(0))    
+                .body("features.size()", is(0))
             ;
 	   }
-	
+
 	@Test
     public void testCustomEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -406,13 +405,13 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
                 ;
 	   }
-	
+
 	@Test
     public void testCustomGeometryEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -426,18 +425,18 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"));
 	   }
-	
+
 	//Point test cases
 	@Test
     public void testCustomPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -453,14 +452,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testCustomGeometryPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -474,18 +473,18 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testCustomPoint2() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 92.46093749999999, \"y\" : 39.095962936305476}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -500,14 +499,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testCustomPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -523,14 +522,14 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testCustomGeometryPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -544,17 +543,17 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testCustomAllFields() throws UnsupportedEncodingException, ParseException  {
 
 		String path = "marklogic/GeoLocation/FeatureServer/{layer}/query?outFields=*";
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 4)
@@ -566,7 +565,7 @@ public class CustomQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}

--- a/test/src/test/java/DataTypes.java
+++ b/test/src/test/java/DataTypes.java
@@ -1,17 +1,16 @@
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 import io.restassured.RestAssured;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.*;
 
 public class DataTypes extends AbstractFeatureServiceTest {
 
     @Test
     public void testDefaultStringLength() throws UnsupportedEncodingException, ParseException  {
 
-        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}";
         RestAssured.urlEncodingEnabled = false;
 
         RestAssured

--- a/test/src/test/java/EnvelopeQueries.java
+++ b/test/src/test/java/EnvelopeQueries.java
@@ -13,9 +13,9 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
 	@Test
     public void testEnvelopeIntersects1() {
 
-        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -31,14 +31,14 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
                 .body("features.attributes.name", hasItems("MarkLogic HQ","Museum","Restaurant","Shopping Center","MarkLogic Neighborhood", "Wildlife Refuge","Airport","Hwy 101","Holly St"))
             ;
 	}
-	
+
 	//testEnvelopeAirportIntersects
 	@Test
     public void testEnvelopeIntersects2() {
 
-        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -52,16 +52,16 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
                 .statusCode(200)
                 .body("features.size()", is(6))
                 .body("features.attributes.name", hasItems("Museum","MarkLogic Neighborhood", "Wildlife Refuge","Airport","Hwy 101","Holly St"))
-            ; 
-	}	
-	
+            ;
+	}
+
 	//testEnvelopeShoppingCentreIntersects
 	@Test
     public void testEnvelopeIntersects3() {
 
-        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -75,16 +75,16 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features[0].attributes.name", is("Shopping Center"))
-            ; 
+            ;
 	}
-	
+
 	//testEnvelopeWildlifeRefugeIntersects
 	@Test
     public void testEnvelopeIntersects4() {
 
-        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -98,16 +98,16 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
                 .statusCode(200)
                 .body("features.size()", is(4))
                 .body("features.attributes.name", hasItems("MarkLogic HQ","MarkLogic Neighborhood", "Wildlife Refuge","Airport"))
-            ; 
+            ;
 	}
 
 	//testEnvelopeAroundPointIntersects
 	@Test
     public void testEnvelopeIntersects5() {
 
-        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -122,16 +122,16 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
                 .body("features.size()", is(2))
                 .body("features.attributes.name", hasItems("Restaurant","MarkLogic Neighborhood"))
 
-            ; 
+            ;
 	}
-	
+
 	//testEnvelopeEmptyIntersects
 	@Test
     public void testEnvelopeIntersects6() {
 
-        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -144,17 +144,17 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
                 .log().ifError()
                 .statusCode(200)
                 .body("features.size()", is(0))
-            ; 
+            ;
 	}
-	
+
 	//=========================Contains============================================
 	//Inside single Envelope - Expected : MarkLogic Neighborhood
 	@Test
     public void testEnvelopeContains1() {
 
-        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -169,16 +169,16 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
                 .log().ifError()
                 .statusCode(200)
                 .body("features.size()", is(1))
-                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))            ; 
+                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))            ;
 	}
-	
+
 	//Inside two Envelope - Expected : MarkLogic Neighborhood , Airport
 		@Test
 	    public void testEnvelopeContains2() {
 
-	        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 	    	RestAssured.urlEncodingEnabled = false;
-	 	
+
 	        RestAssured
 	            .given()
 	            	.pathParam("layer", 3)
@@ -195,14 +195,14 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
 	                .body("features.size()", is(2))
 	                .body("features.attributes.name", hasItems("MarkLogic Neighborhood","Airport"));
 	             		}
-		
-		//Inside a Envelope and intersecting 2 other features - Expected : MarkLogic Neighborhood 
+
+		//Inside a Envelope and intersecting 2 other features - Expected : MarkLogic Neighborhood
 				@Test
 			    public void testEnvelopeContains3() {
 
-			        String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 			    	RestAssured.urlEncodingEnabled = false;
-			 	
+
 			        RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -217,7 +217,7 @@ public class EnvelopeQueries extends AbstractFeatureServiceTest{
 			                .log().ifError()
 			                .statusCode(200)
 			                .body("features.size()", is(1))
-			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))            ; 
+			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))            ;
 			             		}
-		
+
 }

--- a/test/src/test/java/GMLQueries.java
+++ b/test/src/test/java/GMLQueries.java
@@ -3,7 +3,6 @@ import static org.hamcrest.Matchers.*;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import org.hamcrest.core.IsNull;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -14,10 +13,10 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
 	@Test
     public void testGMLPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -33,14 +32,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))
             ;
 		}
-	
+
 	@Test
     public void testGMLGeometryPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -58,14 +57,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
                 ;
 		}
-	
+
 	@Test
     public void testGMLPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -81,14 +80,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
             ;
 		}
-	
+
 	@Test
     public void testGMLGeometryPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -102,18 +101,18 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}
-	
+
 	@Test
     public void testGMLPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -129,14 +128,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testGMLGeometryPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -150,18 +149,18 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testGMLPolygon4() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[74.81689453125,24.666986385216273],[76.6845703125,24.666986385216273],[76.6845703125,25.64152637306577],[74.81689453125,25.64152637306577],[74.81689453125,24.666986385216273]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -176,14 +175,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testGMLPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -199,14 +198,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
-	
+
 	@Test
     public void testGMLGeometryPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -220,18 +219,18 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
 
-	// Envelope Test cases 
+	// Envelope Test cases
 	@Test
     public void testGMLEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -246,13 +245,13 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(14))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))            ;
 	   }
-	
+
 	@Test
     public void testGMLGeometryEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -270,13 +269,13 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
             ;
 	   }
-	
+
 	@Test
     public void testGMLEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -288,17 +287,17 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(17))     
+                .body("features.size()", is(17))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testGMLGeometryEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -312,17 +311,17 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testGMLEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -334,17 +333,17 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(5))    
+                .body("features.size()", is(5))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 	@Test
     public void testGMLGeometryEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -358,18 +357,18 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 
 	@Test
     public void testGMLEnvelope4() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -381,16 +380,16 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(0))    
+                .body("features.size()", is(0))
             ;
 	   }
-	
+
 	@Test
     public void testGMLEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -406,13 +405,13 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
                 ;
 	   }
-	
+
 	@Test
     public void testGMLGeometryEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -426,18 +425,18 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"));
 	   }
-	
+
 	//Point test cases
 	@Test
     public void testGMLPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -453,14 +452,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testGMLGeometryPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -474,18 +473,18 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testGMLPoint2() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 92.46093749999999, \"y\" : 39.095962936305476}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -500,14 +499,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testGMLPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -523,14 +522,14 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testGMLGeometryPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -544,17 +543,17 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testGMLAllFields() throws UnsupportedEncodingException, ParseException  {
 
 		String path = "marklogic/GeoLocation/FeatureServer/{layer}/query?outFields=*";
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 0)
@@ -566,7 +565,7 @@ public class GMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}

--- a/test/src/test/java/GeoJSONGeometry.java
+++ b/test/src/test/java/GeoJSONGeometry.java
@@ -1,9 +1,7 @@
 import static org.hamcrest.Matchers.*;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 
-import org.hamcrest.core.IsNull;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -23,7 +21,7 @@ public class GeoJSONGeometry  extends AbstractFeatureServiceTest {
     @Test
     public void testXPathExtraction() throws UnsupportedEncodingException, ParseException  {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
 
         RestAssured
             .given()
@@ -55,7 +53,7 @@ public class GeoJSONGeometry  extends AbstractFeatureServiceTest {
     @Test
     public void testColumnExtraction() throws UnsupportedEncodingException, ParseException  {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
 
         RestAssured
             .given()
@@ -88,7 +86,7 @@ public class GeoJSONGeometry  extends AbstractFeatureServiceTest {
     @Test
     public void testXPathCtsExtraction() throws UnsupportedEncodingException, ParseException  {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
 
         RestAssured
             .given()

--- a/test/src/test/java/IncludeFieldsTest.java
+++ b/test/src/test/java/IncludeFieldsTest.java
@@ -9,7 +9,7 @@ public class IncludeFieldsTest extends AbstractFeatureServiceTest {
 
     @Test
     public void testIncludeFieldsInFirstDataSourcesObject() {
-        String path = "/marklogic/{service}/FeatureServer/{layer}/query?resultRecordCount={resultRecordCount}&orderByFields={orderByFields}&returnGeometry={returnGeometry}";
+        String path = basePath("{service}") + "/FeatureServer/{layer}/query?resultRecordCount={resultRecordCount}&orderByFields={orderByFields}&returnGeometry={returnGeometry}";
                 RestAssured
                 .given()
                   .pathParam("service", "GDeltGKG")
@@ -44,7 +44,7 @@ public class IncludeFieldsTest extends AbstractFeatureServiceTest {
 
     @Test
     public void testIncludeFieldsInOriginalSource() {
-        String path = "/marklogic/{service}/FeatureServer/{layer}/query?resultRecordCount={resultRecordCount}&orderByFields={orderByFields}&returnGeometry={returnGeometry}";
+        String path = basePath("{service}") + "/FeatureServer/{layer}/query?resultRecordCount={resultRecordCount}&orderByFields={orderByFields}&returnGeometry={returnGeometry}";
         RestAssured
                 .given()
                 .pathParam("service", "GDeltGKG")

--- a/test/src/test/java/KMLQueries.java
+++ b/test/src/test/java/KMLQueries.java
@@ -3,7 +3,6 @@ import static org.hamcrest.Matchers.*;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import org.hamcrest.core.IsNull;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -14,10 +13,10 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
 	@Test
     public void testKMLPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -33,14 +32,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))
             ;
 		}
-	
+
 	@Test
     public void testKMLGeometryPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -58,14 +57,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
                 ;
 		}
-	
+
 	@Test
     public void testKMLPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -81,14 +80,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
             ;
 		}
-	
+
 	@Test
     public void testKMLGeometryPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -102,18 +101,18 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}
-	
+
 	@Test
     public void testKMLPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -129,14 +128,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testKMLGeometryPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -150,18 +149,18 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testKMLPolygon4() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[74.81689453125,24.666986385216273],[76.6845703125,24.666986385216273],[76.6845703125,25.64152637306577],[74.81689453125,25.64152637306577],[74.81689453125,24.666986385216273]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -176,14 +175,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testKMLPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -199,14 +198,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
-	
+
 	@Test
     public void testKMLGeometryPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -220,18 +219,18 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
 
-	// Envelope Test cases 
+	// Envelope Test cases
 	@Test
     public void testKMLEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -246,13 +245,13 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(14))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))            ;
 	   }
-	
+
 	@Test
     public void testKMLGeometryEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -270,13 +269,13 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
             ;
 	   }
-	
+
 	@Test
     public void testKMLEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -288,17 +287,17 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(17))     
+                .body("features.size()", is(17))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testKMLGeometryEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -312,17 +311,17 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testKMLEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -334,17 +333,17 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(5))    
+                .body("features.size()", is(5))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 	@Test
     public void testKMLGeometryEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -358,18 +357,18 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 
 	@Test
     public void testKMLEnvelope4() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -381,16 +380,16 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(0))    
+                .body("features.size()", is(0))
             ;
 	   }
-	
+
 	@Test
     public void testKMLEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -406,13 +405,13 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
                 ;
 	   }
-	
+
 	@Test
     public void testKMLGeometryEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -426,18 +425,18 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"));
 	   }
-	
+
 	//Point test cases
 	@Test
     public void testKMLPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -453,14 +452,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testKMLGeometryPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -474,18 +473,18 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testKMLPoint2() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 92.46093749999999, \"y\" : 39.095962936305476}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -500,14 +499,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testKMLPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -523,14 +522,14 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testKMLGeometryPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -544,17 +543,17 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testKMLAllFields() throws UnsupportedEncodingException, ParseException  {
 
 		String path = "marklogic/GeoLocation/FeatureServer/{layer}/query?outFields=*";
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 1)
@@ -566,7 +565,7 @@ public class KMLQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}

--- a/test/src/test/java/LineStringQueries.java
+++ b/test/src/test/java/LineStringQueries.java
@@ -15,10 +15,10 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 	@Test
     public void testLineStringCrosses1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 		String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.26143836975098,37.51217686964284],[-122.25603103637695,37.50897690205704]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -33,17 +33,17 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features[0].attributes.name", is("Holly St"))
-                ;                                                       
+                ;
 		}
-	
+
 	//Crosses Double line = Expected : WildLife refuge
 		@Test
 	    public void testLineStringCrosses2() throws UnsupportedEncodingException, ParseException  {
 
-			String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 			String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.2555160522461,37.51660213066696],[-122.25422859191895,37.51020243776711]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 			RestAssured.urlEncodingEnabled = false;
-	 		
+
 	    	RestAssured
 	            .given()
 	            	.pathParam("layer", 3)
@@ -58,17 +58,17 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 	                .statusCode(200)
 	                .body("features.size()", is(2))
 	                .body("features.attributes.name", hasItems("Hwy 101","Holly St"));
-	                ;                                                       
+	                ;
 			}
-		
+
 		//Crosses Lines and Polygons = Expected : 6 features
 				@Test
 			    public void testLineStringCrosses3() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.25688934326172,37.51707868158789],[-122.25680351257324,37.511291785950505],[-122.24864959716797,37.50169135780772],[-122.24985122680663,37.514083168101116],[-122.24375724792479,37.512721531313645]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -81,19 +81,19 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 			            .then()
 			                .log().ifError()
 			                .statusCode(200)
-			                .body("features.size()", is(6))    
-			                .body("features.attributes.name", hasItems("MarkLogic Neighborhood","Shopping Center","Wildlife Refuge","Hwy 101","Holly St","Airport"))            ;                                                       			             
-			                ;                                                       
+			                .body("features.size()", is(6))
+			                .body("features.attributes.name", hasItems("MarkLogic Neighborhood","Shopping Center","Wildlife Refuge","Hwy 101","Holly St","Airport"))            ;
+			                ;
 					}
-				
+
 				//Crosses Polygons = Expected : WildLife refuge
 				@Test
 			    public void testLineStringCrosses4() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.2397232055664,37.51925716132821],[-122.23809242248537,37.505436352534616]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -106,21 +106,21 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 			            .then()
 			                .log().ifError()
 			                .statusCode(200)
-			                .body("features.size()", is(1))    
+			                .body("features.size()", is(1))
 			                .body("features[0].attributes.name", is("Wildlife Refuge"))
-			                ;                                                       
+			                ;
 					}
-				
+
 				//http://localhost:9080/marklogic/GDeltGKG/FeatureServer/3/query?geometryType=esriGeometryPolygon&geometry={"paths":[[[-122.24143981933594,37.520720791683374],[-122.24156856536865,37.51432145198483]]],"spatialReference" : {"wkid" : 4326}}
 
 				//Intersect single Polygons = Expected : WildLife refuge
 				@Test
 			    public void testLineStringIntersect1() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 					String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.24143981933594,37.520720791683374],[-122.24156856536865,37.51432145198483]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -132,19 +132,19 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 			            .then()
 			                .log().ifError()
 			                .statusCode(200)
-			                .body("features.size()", is(1))    
+			                .body("features.size()", is(1))
 			                .body("features[0].attributes.name", is("Wildlife Refuge"))
-			                ;                                                       
+			                ;
 					}
-				
+
 				//Intersect Two Polygons = Expected : WildLife refuge, MLNH
 				@Test
 			    public void testLineStringIntersect2() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 					String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.24324226379393,37.5124492009751],[-122.24710464477538,37.51210878665452]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -158,17 +158,17 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 			                .statusCode(200)
 			                .body("features.size()", is(2))
 			                .body("features.attributes.name", hasItems("Wildlife Refuge","MarkLogic Neighborhood"));
-			                ;                                                       
+			                ;
 					}
-				
+
 				//Intersect Multiple Polygons and LineString = Expected : 4 features
 				@Test
 			    public void testLineStringIntersect3() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 					String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.25414276123047,37.505844886049545],[-122.25457191467285,37.511496036964935],[-122.24684715270996,37.51217686964284],[-122.24135398864748,37.51108753437713],[-122.24195480346678,37.50918115940604]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -182,17 +182,17 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 			                .statusCode(200)
 			                .body("features.size()", is(4))
 			                .body("features.attributes.name", hasItems("Airport","Wildlife Refuge","MarkLogic Neighborhood","Hwy 101"));
-			                ;                                                       
+			                ;
 					}
-				
+
 				//Complete inside polygon without Intersection = Expected :MLNH
 				@Test
 			    public void testLineStringIntersect4() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 					String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.25654602050781,37.51081519807655],[-122.25688934326172,37.50693429782622]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -205,18 +205,18 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 			                .log().ifError()
 			                .statusCode(200)
 			                .body("features.size()", is(1))
-			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))			                ;                                                       
+			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))			                ;
 					}
-				
+
 				//Reverse test -polyline with one end as a point in database  Expected : MLNH
 
 				@Test
 			    public void testLineStringIntersect5() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 					String GeometryEncoded = URLEncoder.encode("{\"paths\":[[[-122.26075172424316,37.511836454080196],[-122.2582,37.5128]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -229,6 +229,6 @@ public class LineStringQueries extends AbstractFeatureServiceTest{
 			                .log().ifError()
 			                .statusCode(200)
 			                .body("features.size()", is(1))
-			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))			                ;                                                       
+			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))			                ;
 					}
 }

--- a/test/src/test/java/MCGMQueries.java
+++ b/test/src/test/java/MCGMQueries.java
@@ -3,7 +3,6 @@ import static org.hamcrest.Matchers.*;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import org.hamcrest.core.IsNull;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -14,10 +13,10 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
 	@Test
     public void testMCGMPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -33,14 +32,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMGeometryPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -58,14 +57,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
                 ;
 		}
-	
+
 	@Test
     public void testMCGMPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -81,14 +80,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMGeometryPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -102,18 +101,18 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}
-	
+
 	@Test
     public void testMCGMPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -129,14 +128,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMGeometryPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -150,18 +149,18 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMPolygon4() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[74.81689453125,24.666986385216273],[76.6845703125,24.666986385216273],[76.6845703125,25.64152637306577],[74.81689453125,25.64152637306577],[74.81689453125,24.666986385216273]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -176,14 +175,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testMCGMPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -199,14 +198,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMGeometryPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -220,18 +219,18 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
 
-	// Envelope Test cases 
+	// Envelope Test cases
 	@Test
     public void testMCGMEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -246,13 +245,13 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(14))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))            ;
 	   }
-	
+
 	@Test
     public void testMCGMGeometryEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -270,13 +269,13 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
             ;
 	   }
-	
+
 	@Test
     public void testMCGMEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -288,17 +287,17 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(17))     
+                .body("features.size()", is(17))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testMCGMGeometryEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -312,17 +311,17 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testMCGMEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -334,17 +333,17 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(5))    
+                .body("features.size()", is(5))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 	@Test
     public void testMCGMGeometryEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -358,18 +357,18 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 
 	@Test
     public void testMCGMEnvelope4() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -381,16 +380,16 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(0))    
+                .body("features.size()", is(0))
             ;
 	   }
-	
+
 	@Test
     public void testMCGMEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -406,13 +405,13 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
                 ;
 	   }
-	
+
 	@Test
     public void testMCGMGeometryEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -426,18 +425,18 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"));
 	   }
-	
+
 	//Point test cases
 	@Test
     public void testMCGMPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -453,14 +452,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMGeometryPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -474,18 +473,18 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMPoint2() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 92.46093749999999, \"y\" : 39.095962936305476}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -500,14 +499,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testMCGMPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -523,14 +522,14 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMGeometryPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -544,17 +543,17 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testMCGMAllFields() throws UnsupportedEncodingException, ParseException  {
 
 		String path = "marklogic/GeoLocation/FeatureServer/{layer}/query?outFields=*";
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -566,7 +565,7 @@ public class MCGMQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}

--- a/test/src/test/java/PointQueries.java
+++ b/test/src/test/java/PointQueries.java
@@ -15,10 +15,10 @@ public class PointQueries  extends AbstractFeatureServiceTest {
 	@Test
     public void testPointIntersects1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : -122.25972175598143, \"y\" : 37.51871254735555}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -34,15 +34,15 @@ public class PointQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("MarkLogic Neighborhood"))
             ;
 		}
-	
+
 	//testTwoPolygonIntersects
 	@Test
     public void testPointIntersects2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : -122.24564552307129, \"y\" : 37.513198107015064}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -57,16 +57,16 @@ public class PointQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(2))
                 .body("features.attributes.name", hasItems("Wildlife Refuge","MarkLogic Neighborhood"));
 		}
-	
-	
+
+
 	//Inside single polygon Expected- WildLife Refuge
 	@Test
     public void testPointContains1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 		String GeometryEncoded = URLEncoder.encode("{\"x\" :-122.2411823272705, \"y\" : 37.50918115940604}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -83,15 +83,15 @@ public class PointQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(1))
                 .body("features[0].attributes.name", is("Wildlife Refuge"));
 		}
-	
+
 	//Inside two polygon Expected- WildLife Refuge
 		@Test
 	    public void testPointContains2() throws UnsupportedEncodingException, ParseException  {
 
-			String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 			String GeometryEncoded = URLEncoder.encode("{\"x\" :-122.25208282470703, \"y\" : 37.51571709945411}" ,"UTF-8");
 			RestAssured.urlEncodingEnabled = false;
-	 		
+
 	    	RestAssured
 	            .given()
 	            	.pathParam("layer", 3)
@@ -108,15 +108,15 @@ public class PointQueries  extends AbstractFeatureServiceTest {
 	                .body("features.size()", is(2))
 	                .body("features.attributes.name", hasItems("Airport","MarkLogic Neighborhood"));
 			}
-		
+
 		//External Point Expected- No Features
 				@Test
 			    public void testPointContains3() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"x\" :-122.24152565002441, \"y\" : 37.52068675409422}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -130,6 +130,6 @@ public class PointQueries  extends AbstractFeatureServiceTest {
 			            .then()
 			                .log().ifError()
 			                .statusCode(200)
-			                .body("features.size()", is(0));					
+			                .body("features.size()", is(0));
 			    	}
 }

--- a/test/src/test/java/PolygonQueries.java
+++ b/test/src/test/java/PolygonQueries.java
@@ -1,24 +1,23 @@
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import org.json.simple.parser.ParseException;
-import org.junit.Ignore;
 import org.junit.Test;
 import io.restassured.RestAssured;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.*;
 
 public class PolygonQueries extends AbstractFeatureServiceTest {
-	
+
     //===============================Intersect=============================================
 
 	//Wildlife Refuge testSinglePolygonIntersects
 	@Test
     public void testPolygonIntersects1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.23714828491211,37.50884073018052],[-122.23302841186523,37.50884073018052],[-122.23302841186523,37.51524053983815],[-122.23714828491211,37.51524053983815],[-122.23714828491211,37.50884073018052]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -34,15 +33,15 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Wildlife Refuge"))
             ;
 		}
-	
+
 	//testSinglePolygonLineStringIntersects1 Expected : Marklogic neighbourhood, (Holly St)Linestring
 	@Test
     public void testPolygonIntersects2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.2529411315918,37.52313742082534],[-122.25697517395018,37.52225246712464],[-122.25646018981932,37.51871254735555],[-122.25199699401855,37.51782754117213],[-122.25096702575684,37.52191209752169],[-122.2529411315918,37.52313742082534]]],\"spatialReference\":{\"wkid\":4326 }}","UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -57,15 +56,15 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .body("features.size()", is(2))
                 .body("features.attributes.name", hasItems("Holly St","MarkLogic Neighborhood"))            ;
 		}
-	
+
 	//testSinglePolygonLineStringIntersects2 Expected : Holly ST(LineString) , Airport (Polygon)
 	@Test
     public void testPolygonIntersects3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.25555896759033,37.51660213066696],[-122.25264072418213,37.51513841952452],[-122.25173950195311,37.51626173528878],[-122.25495815277098,37.51728291676527],[-122.25555896759033,37.51660213066696]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -78,18 +77,18 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .log().ifError()
                 .statusCode(200)
                 .body("features.size()", is(3))
-                .body("features.attributes.name", hasItems("Airport","Holly St","MarkLogic Neighborhood"))            ;                       
-                
+                .body("features.attributes.name", hasItems("Airport","Holly St","MarkLogic Neighborhood"))            ;
+
 		}
-	
+
 	//testTwoLineStringIntersects Expected : Cross two linestrings- Holly ST & Hy 101
 	@Test
     public void testPolygonIntersects4() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.25622415542603,37.514763977179],[-122.25680351257324,37.513844883456606],[-122.2561812400818,37.513283209498645],[-122.25500106811522,37.51410018840375],[-122.25622415542603,37.514763977179]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -102,7 +101,7 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .log().ifError()
                 .statusCode(200)
                 .body("features.size()", is(3))
-                .body("features.attributes.name", hasItems("Hwy 101","Holly St","MarkLogic Neighborhood"))     
+                .body("features.attributes.name", hasItems("Hwy 101","Holly St","MarkLogic Neighborhood"))
             ;
 		}
 
@@ -110,10 +109,10 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 	@Test
     public void testPolygonIntersects5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.26568698883058,37.51358957763611],[-122.26609468460083,37.51243218029593],[-122.2649359703064,37.511768370781354],[-122.26360559463501,37.5128747166924],[-122.26568698883058,37.51358957763611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -128,15 +127,15 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	// Only cross outer polygon ( Should return only outer polygon)
 	@Test
     public void testPolygonIntersects6() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.26446390151976,37.51570007952023],[-122.26465702056885,37.51522351979558],[-122.26313352584839,37.51472993687259],[-122.2623825073242,37.51587027868436],[-122.26405620574951,37.51626173528878],[-122.26446390151976,37.51570007952023]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -152,15 +151,15 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("MarkLogic Neighborhood"))
                 ;
 		}
-	
+
 	//Only covering one point (Should return the point and Outer polygon)
 	@Test
     public void testPolygonIntersects7() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.25903511047362,37.513998066529716],[-122.25912094116212,37.51290875784499],[-122.25779056549074,37.512534304312624],[-122.2571897506714,37.51358957763611],[-122.25903511047362,37.513998066529716]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -173,19 +172,19 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .log().ifError()
                 .statusCode(200)
                 .body("features.size()", is(2))
-                .body("features.attributes.name", hasItems("Restaurant","MarkLogic Neighborhood"))            ;                                                       
+                .body("features.attributes.name", hasItems("Restaurant","MarkLogic Neighborhood"))            ;
 		}
 
     //================================Within=======================================
 
-	//Polygon1 ( Features within Polygon )  Expected : Restaurant 
+	//Polygon1 ( Features within Polygon )  Expected : Restaurant
 	@Test
     public void testPolygonWithin1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.25903511047362,37.513998066529716],[-122.25912094116212,37.51290875784499],[-122.25779056549074,37.512534304312624],[-122.2571897506714,37.51358957763611],[-122.25903511047362,37.513998066529716]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -199,18 +198,18 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .log().ifError()
                 .statusCode(200)
                 .body("features.size()", is(1))
-                .body("features[0].attributes.name", is("Restaurant"))            ;                                                       
+                .body("features[0].attributes.name", is("Restaurant"))            ;
 		}
-	
-	
-	//Polygon2 ( Features within Polygon )  Expected : Airport 
+
+
+	//Polygon2 ( Features within Polygon )  Expected : Airport
 	@Test
     public void testPolygonWithin2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.2487354,37.5181339],[-122.250967,37.5177254],[-122.2537994,37.5157171],[-122.2543144,37.5148321],[-122.2466755,37.5083982],[-122.2457314,37.5086705],[-122.2481775,37.5121769],[-122.2487354,37.5181339]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -224,17 +223,17 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .log().ifError()
                 .statusCode(200)
                 .body("features.size()", is(1))
-                .body("features[0].attributes.name", is("Airport"))            ;                                                       
+                .body("features[0].attributes.name", is("Airport"))            ;
 		}
-	
-	//Polygon3 ( Features within Polygon - Around MarkLogic NH)  Expected : 6 features 
+
+	//Polygon3 ( Features within Polygon - Around MarkLogic NH)  Expected : 6 features
 	@Test
     public void testPolygonWithin3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.2634554,37.519087],[-122.2633696,37.5134364],[-122.2598076,37.5061853],[-122.2455597,37.5033596],[-122.2446156,37.512279],[-122.2480488,37.5212994],[-122.2634554,37.519087]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 3)
@@ -248,13 +247,13 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
                 .log().ifError()
                 .statusCode(200)
                 .body("features.size()", is(6))
-                .body("features.attributes.name", hasItems("MarkLogic Neighborhood","Restaurant","Holly St","Airport","Museum","MarkLogic HQ"))            ;                                                       
-                ;                                                       
+                .body("features.attributes.name", hasItems("MarkLogic Neighborhood","Restaurant","Holly St","Airport","Museum","MarkLogic HQ"))            ;
+                ;
 		}
 
 		@Test
 	    public void testPolygonWithin4() throws UnsupportedEncodingException {
-			String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 			String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.2428131,37.517351],[-122.2468472,37.5131641],[-122.2422123,37.5069683],[-122.2356892,37.5102365],[-122.2384787,37.5154788],[-122.2428131,37.517351]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 			RestAssured.urlEncodingEnabled = false;
 
@@ -279,15 +278,15 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 	                .body("features.size()", is(1))
 					.body("features[0].attributes.name", is("Wildlife Refuge"));
 			}
-		
+
 		//Polygon5 (Features within Polygon - WIldLife refuge)  Expected : WildLife refuge
 				@Test
 			    public void testPolygonWithin5() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.24058151245116,37.51827004557588],[-122.2474479675293,37.51748715138366],[-122.24873542785645,37.51159816226253],[-122.24259853363036,37.50567466402333],[-122.23311424255371,37.50839816986626],[-122.2344446182251,37.515104379388916],[-122.24058151245116,37.51827004557588]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -302,17 +301,17 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			                .statusCode(200)
 			                .body("features.size()", is(1))
 			                .body("features[0].attributes.name", is("Wildlife Refuge"))
-			                ;                                                       
+			                ;
 					}
-				
+
 				//Polygon6 (Reverse Test -Intersecting wildlife refuge - not within )  Expected : Zero results
 				@Test
 			    public void testPolygonWithin6() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.23937988281251,37.51748715138366],[-122.24380016326903,37.514389532954716],[-122.24637508392334,37.50999818321275],[-122.24092483520508,37.505061861515316],[-122.23294258117676,37.50979392809947],[-122.23937988281251,37.51748715138366]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -325,17 +324,17 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			            .then()
 			                .log().ifError()
 			                .statusCode(200)
-			                .body("features.size()", is(0))			                ;                                                       
+			                .body("features.size()", is(0))			                ;
 					}
-				
+
 				//Polygon7 (Reverse Test -External polygon - Not related to any feature )  Expected : Zero results
 				@Test
 			    public void testPolygonWithin7() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.23491668701172,37.51704464233734],[-122.23637580871582,37.5151724596446],[-122.23470211029051,37.51295981954475],[-122.23011016845702,37.5140491274842],[-122.23066806793211,37.515649019695296],[-122.23491668701172,37.51704464233734]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -348,19 +347,19 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			            .then()
 			                .log().ifError()
 			                .statusCode(200)
-			                .body("features.size()", is(0))			                ;                                                       
+			                .body("features.size()", is(0))			                ;
 					}
-				
-//=============================================Contains====================================================		
-				
+
+//=============================================Contains====================================================
+
 				//Polygon1 Contains (Inside single polygon )  Expected : WildLife refuge
 				@Test
 			    public void testPolygonContains1() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.2418689727783,37.513810842731],[-122.24289894104004,37.511155618297025],[-122.24032402038574,37.51033860715949],[-122.23852157592772,37.5124492009751],[-122.2418689727783,37.513810842731]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -375,18 +374,18 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			                .statusCode(200)
 			                .body("features.size()", is(1))
 			                .body("features[0].attributes.name", is("Wildlife Refuge"))
-			                ;                                                       
+			                ;
 					}
-				
-				
+
+
 				//Polygon2 Contains (Inside two polygon )  Expected : Airport, MLNH
 				@Test
 			    public void testPolygonContains2() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.25113868713377,37.5159894178683],[-122.24950790405273,37.514763977179],[-122.24907875061034,37.5159213383579],[-122.25053787231444,37.51694252449245],[-122.25113868713377,37.5159894178683]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -401,19 +400,19 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			                .statusCode(200)
 			                .body("features.size()", is(2))
 			                .body("features.attributes.name", hasItems("MarkLogic Neighborhood","Airport"))
-			                ;                                                       
+			                ;
 					}
-				
-				
-				
+
+
+
 				//Polygon2 Contains ( Inside a polygon and intersecting 2 other polygons )  Expected : A, MLNH
 				@Test
 			    public void testPolygonContains3() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.24907875061034,37.51067902955361],[-122.24547386169434,37.51067902955361],[-122.24547386169434,37.51367467967332],[-122.24907875061034,37.51367467967332],[-122.24907875061034,37.51067902955361]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -428,19 +427,19 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			                .statusCode(200)
 			                .body("features.size()", is(1))
 			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))
-			                ;                                                       
+			                ;
 					}
-				
-				
+
+
 				//==================================Touch===========================================
 				// Touched Hvy 101(Linestring) ( from Endpoint )
 				@Test
 			    public void testPolygonTouches1() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.26343393325807,37.521410049523055],[-122.26358413696288,37.52209930099547],[-122.26560115814208,37.5216312914303],[-122.26503252983092,37.520746319865054],[-122.2637558,37.5206187],[-122.26343393325807,37.521410049523055]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -455,17 +454,17 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			                .statusCode(200)
 			                .body("features.size()", is(1))
 			                .body("features[0].attributes.name", is("Hwy 101"))
-			                ;                                                       
-					}					
-				
+			                ;
+					}
+
 				// Reverse test ( Intersecting )
 				@Test
 			    public void testPolygonTouches2() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.25295186042784,37.511104555362934],[-122.25335955619813,37.51095987685995],[-122.25354194641113,37.51062796629347],[-122.25318789482115,37.510381160043664],[-122.25250124931334,37.510764134909536],[-122.25295186042784,37.511104555362934]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -478,17 +477,17 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			            .then()
 			                .log().ifError()
 			                .statusCode(200)
-			                .body("features.size()", is(0))			                ;                                                       
-					}					
-				
+			                .body("features.size()", is(0))			                ;
+					}
+
 				//Not touching anything
 				@Test
 			    public void testPolygonTouches3() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.26343393325807,37.521410049523055],[-122.26358413696288,37.52209930099547],[-122.26560115814208,37.5216312914303],[-122.26503252983092,37.520746319865054],[-122.26404547691345,37.52091650751973],[-122.26343393325807,37.521410049523055]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -502,18 +501,18 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			                .log().ifError()
 			                .statusCode(200)
 			                .body("features.size()", is(0))
-			                ;                                                       
+			                ;
 					}
-				
+
 	//==============================overlap=========================================
-				
+
 				@Test
 			    public void testPolygonOverlaps1() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.25843429565428,37.51871254735555],[-122.25431442260741,37.51871254735555],[-122.25431442260741,37.52170787501458],[-122.25843429565428,37.52170787501458],[-122.25843429565428,37.51871254735555]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -527,16 +526,16 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			                .log().ifError()
 			                .statusCode(200)
 			                .body("features.size()", is(1))
-			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))			                ;                                                       
+			                .body("features[0].attributes.name", is("MarkLogic Neighborhood"))			                ;
 					}
-				
+
 				@Test
 			    public void testPolygonOverlaps2() throws UnsupportedEncodingException, ParseException  {
 
-					String path = "/marklogic/GDeltGKG/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
+        String path = basePath("GDeltGKG") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&spatialRel={spatialRel}";
 					String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[-122.23766326904297,37.507410910479315],[-122.23551750183105,37.507410910479315],[-122.23551750183105,37.513810842731],[-122.23766326904297,37.513810842731],[-122.23766326904297,37.507410910479315]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 					RestAssured.urlEncodingEnabled = false;
-			 		
+
 			    	RestAssured
 			            .given()
 			            	.pathParam("layer", 3)
@@ -550,6 +549,6 @@ public class PolygonQueries extends AbstractFeatureServiceTest {
 			                .log().ifError()
 			                .statusCode(200)
 			                .body("features.size()", is(1))
-			                .body("features[0].attributes.name", is("Wildlife Refuge"))			                ;                                                       
+			                .body("features[0].attributes.name", is("Wildlife Refuge"))			                ;
 					}
 	}

--- a/test/src/test/java/RSSQueries.java
+++ b/test/src/test/java/RSSQueries.java
@@ -3,7 +3,6 @@ import static org.hamcrest.Matchers.*;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import org.hamcrest.core.IsNull;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -14,10 +13,10 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
 	@Test
     public void testRSSPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -33,14 +32,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))
             ;
 		}
-	
+
 	@Test
     public void testRSSGeometryPolygon1() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[60.99609375,9.96885060854611],[86.1328125,9.96885060854611],[86.1328125,37.78808138412046],[60.99609375,37.78808138412046],[60.99609375,9.96885060854611]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -58,14 +57,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
                 ;
 		}
-	
+
 	@Test
     public void testRSSPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -81,14 +80,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
             ;
 		}
-	
+
 	@Test
     public void testRSSGeometryPolygon2() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[54.58007812499999,2.3723687086440504],[105.99609375,2.3723687086440504],[105.99609375,41.178653972331674],[54.58007812499999,41.178653972331674],[54.58007812499999,2.3723687086440504]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -102,18 +101,18 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}
-	
+
 	@Test
     public void testRSSPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -129,14 +128,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testRSSGeometryPolygon3() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[70.57617187499999,25.720735134412106],[83.5400390625,25.720735134412106],[83.5400390625,34.08906131584994],[70.57617187499999,34.08906131584994],[70.57617187499999,25.720735134412106]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -150,18 +149,18 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 		}
-	
+
 	@Test
     public void testRSSPolygon4() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[74.81689453125,24.666986385216273],[76.6845703125,24.666986385216273],[76.6845703125,25.64152637306577],[74.81689453125,25.64152637306577],[74.81689453125,24.666986385216273]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -176,14 +175,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testRSSPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -199,14 +198,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
-	
+
 	@Test
     public void testRSSGeometryPolygon5() throws UnsupportedEncodingException, ParseException  {
 
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 		String GeometryEncoded = URLEncoder.encode("{\"rings\":[[[69.345703125,20.097206227083888],[74.1357421875,20.097206227083888],[74.1357421875,24.026396666017327],[69.345703125,24.026396666017327],[69.345703125,20.097206227083888]]],\"spatialReference\":{\"wkid\":4326}}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -220,18 +219,18 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"))
             ;
 		}
 
-	// Envelope Test cases 
+	// Envelope Test cases
 	@Test
     public void testRSSEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -246,13 +245,13 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(14))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana"))            ;
 	   }
-	
+
 	@Test
     public void testRSSGeometryEnvelope1() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -270,13 +269,13 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.geometry.points.size()", not(0))
             ;
 	   }
-	
+
 	@Test
     public void testRSSEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -288,17 +287,17 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(17))     
+                .body("features.size()", is(17))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testRSSGeometryEnvelope2() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -312,17 +311,17 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 	   }
-	
+
 	@Test
     public void testRSSEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -334,17 +333,17 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(5))    
+                .body("features.size()", is(5))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 	@Test
     public void testRSSGeometryEnvelope3() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -358,18 +357,18 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(5))
                 .body("features.geometry.size()", is(5))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Himachal Pradesh","Uttar Pradesh","Jammu and Kashmir","Rajasthan","Haryana"))
             ;
 	   }
-	
+
 
 	@Test
     public void testRSSEnvelope4() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -381,16 +380,16 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
             .then()
                 .log().ifError()
                 .statusCode(200)
-                .body("features.size()", is(0))    
+                .body("features.size()", is(0))
             ;
 	   }
-	
+
 	@Test
     public void testRSSEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -406,13 +405,13 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.attributes.name", hasItems("Gujarat"))
                 ;
 	   }
-	
+
 	@Test
     public void testRSSGeometryEnvelope5() {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
     	RestAssured.urlEncodingEnabled = false;
- 	
+
         RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -426,18 +425,18 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Gujarat"));
 	   }
-	
+
 	//Point test cases
 	@Test
     public void testRSSPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -453,14 +452,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testRSSGeometryPoint1() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 73.432617, \"y\" : 27.391277}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -474,18 +473,18 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Rajasthan"))
             ;
 		}
-	
+
 	@Test
     public void testRSSPoint2() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 92.46093749999999, \"y\" : 39.095962936305476}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -500,14 +499,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features.size()", is(0))
             ;
 		}
-	
+
 	@Test
     public void testRSSPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -523,14 +522,14 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testRSSGeometryPoint3() throws UnsupportedEncodingException, ParseException  {
-		String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?geometryType={geometryType}&geometry={geometry}&returnGeometry=true";
 
 		String GeometryEncoded = URLEncoder.encode("{\"x\" : 84.803467, \"y\" : 20.940920}" ,"UTF-8");
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -544,17 +543,17 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(1))
                 .body("features.geometry.size()", is(1))
-                .body("features.geometry.points.size()", not(0)) 
+                .body("features.geometry.points.size()", not(0))
                 .body("features[0].attributes.name", is("Odisha"))
             ;
 		}
-	
+
 	@Test
     public void testRSSAllFields() throws UnsupportedEncodingException, ParseException  {
 
 		String path = "marklogic/GeoLocation/FeatureServer/{layer}/query?outFields=*";
 		RestAssured.urlEncodingEnabled = false;
- 		
+
     	RestAssured
             .given()
             	.pathParam("layer", 2)
@@ -566,7 +565,7 @@ public class RSSQueries  extends AbstractFeatureServiceTest {
                 .statusCode(200)
                 .body("features.size()", is(17))
                 .body("features.geometry.size()", is(17))
-                .body("features.geometry.points.size()", not(0))      
+                .body("features.geometry.points.size()", not(0))
                 .body("features.attributes.name", hasItems("Kerala","Himachal Pradesh","Odisha","Chhattisgarh","Madhya Pradesh","Uttar Pradesh","Jammu and Kashmir","Karnataka","Rajasthan","Maharashtra","Gujarat","Haryana","Tamil Nadu","Telangana","West Bengal","Assam","Tripura"))
                 ;
 		}

--- a/test/src/test/java/WKTGeometry.java
+++ b/test/src/test/java/WKTGeometry.java
@@ -1,9 +1,7 @@
 import static org.hamcrest.Matchers.*;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 
-import org.hamcrest.core.IsNull;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 
@@ -23,7 +21,7 @@ public class WKTGeometry  extends AbstractFeatureServiceTest {
     @Test
     public void testXPathExtraction() throws UnsupportedEncodingException, ParseException  {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
 
         RestAssured
             .given()
@@ -55,7 +53,7 @@ public class WKTGeometry  extends AbstractFeatureServiceTest {
     @Test
     public void testColumnExtraction() throws UnsupportedEncodingException, ParseException  {
 
-        String path = "/marklogic/GeoLocation/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
+        String path = basePath("GeoLocation") + "/FeatureServer/{layer}/query?ids={ids}&returnGeometry={returnGeometry}";
 
         RestAssured
             .given()


### PR DESCRIPTION
This will make it a lot easier to upgrade to the new Koop, which changes the base path from "/marklogic/" to "/marklogic/rest/services/". 