### PR TITLE
Simplifying the test setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ follow the CONTRIBUTING guide for that repository in order to deploy the test ap
 These tests depend on hitting 2 different Koop servers:
 
 1. A Koop server on port 8090 that doesn't require authentication.
-2. A Koop server on port 8092 that requires MarkLogic-based authentication.
+2. A Koop server on port 8091 that requires MarkLogic-based authentication.
 
 To run the tests with both Koop servers active, do the following:
 
@@ -35,8 +35,4 @@ You can also run these tests from Intellij. You'll need to run the Koop servers 
 run this first from the root project directory so that you have a Koop server that doesn't require auth and points to 
 port 8096 in your MarkLogic instance:
 
-    npm run start-no-auth
-
-If you want to run `MarkLogicAuthTest`, you'll also need to run this in a separate terminal:
-
-    npm run start-ml-auth
+    npm run start-for-tests

--- a/config/test-auth-ml.json
+++ b/config/test-auth-ml.json
@@ -2,7 +2,7 @@
   "logger": {
     "level": "info"
   },
-  "port": 8092,
+  "port": 8091,
   "marklogic": {
     "connection": {
       "host": "localhost",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "start-no-auth": "NODE_ENV=test-auth-none node server.js",
-    "start-ml-auth": "NODE_ENV=test-auth-ml node server.js"
+    "start-for-tests": "NODE_ENV=test-auth-none node server.js & NODE_ENV=test-auth-ml node server.js"
   },
   "dependencies": {
     "config": "^3.3.9",

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -15,24 +15,11 @@ dependencies {
     testImplementation "com.googlecode.json-simple:json-simple:1.1.1"
 }
 
-task runNoAuthKoop(type: com.github.psxpaul.task.ExecFork) {
-    description = "Run a Koop server with no authentication required"
+task runKoopServers(type: com.github.psxpaul.task.ExecFork) {
+    description = "Run the Koop servers needed by the tests"
     executable = "npm"
-    args = ["run", "start-no-auth"]
+    args = ["run", "start-for-tests"]
     workingDir = ".."
     waitForPort = 8090
 }
-
-task runMarkLogicAuthKoop(type: com.github.psxpaul.task.ExecFork) {
-    description = "Run a Koop server using MarkLogic-based authentication"
-    executable = "npm"
-    args = ["run", "start-ml-auth"]
-    workingDir = ".."
-    waitForPort = 8092
-}
-
-task runKoopServers {
-    description = "Run the Koop servers that the JUnit tests depend on"
-}
-runKoopServers.dependsOn runNoAuthKoop, runMarkLogicAuthKoop
 test.mustRunAfter runKoopServers

--- a/test/src/test/java/MarkLogicAuthTest.java
+++ b/test/src/test/java/MarkLogicAuthTest.java
@@ -8,14 +8,12 @@ import static org.hamcrest.Matchers.is;
 /**
  * Verifies that "MarkLogic auth" works - i.e. the client sends a MarkLogic username/password, and that's verified
  * against MarkLogic, and then our provider returns an access token.
- *
- * Depends on "npm run start-ml-auth" running.
  */
 public class MarkLogicAuthTest extends AbstractFeatureServiceTest{
 
     @BeforeClass
     public static void connectToMarkLogicAuthKoop() {
-        RestAssured.port = 8092;
+        RestAssured.port = 8091;
         RestAssured.baseURI = "http://localhost";
     }
 


### PR DESCRIPTION
"npm run start-for-tests" now runs both Koop processes so all the tests from Intellij will pass. 