### PR TITLE
Simplified server.js

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,19 +1,19 @@
 {
-  "logger" : {
-    "level" : "debug"
+  "logger": {
+    "level": "info"
   },
-  "port" : 80,
+  "port": 80,
   "ssl": {
-    "enabled" : false,
-    "port" : 443,
-    "cert" : "/ssl/cert.pem",
-    "key" : "/ssl/key.pem"
+    "enabled": false,
+    "port": 443,
+    "cert": "/ssl/cert.pem",
+    "key": "/ssl/key.pem"
   },
   "marklogic": {
     "connection": {
-      "host":     "localhost",
-      "port":     8095,
-      "user":     "sample-writer",
+      "host": "localhost",
+      "port": 8095,
+      "user": "sample-writer",
       "password": "sample-writer",
       "authType": "DIGEST"
     }

--- a/config/test-auth-none.json
+++ b/config/test-auth-none.json
@@ -1,13 +1,13 @@
 {
-  "logger" : {
-    "level" : "info"
+  "logger": {
+    "level": "info"
   },
-  "port" : 8090,
+  "port": 8090,
   "marklogic": {
     "connection": {
-      "host":     "localhost",
-      "port":     8096,
-      "user":     "test-geo-data-services-writer",
+      "host": "localhost",
+      "port": 8096,
+      "user": "test-geo-data-services-writer",
       "password": "test-geo-data-services-writer",
       "authType": "DIGEST"
     }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       context: .
     ports:
       - "9100:9000"
-      - "9443:9443" # HTTPS port which will only be open if ssl.enabled=true in provider-config.json
     hostname: "koop"
     container_name: "koop"
     environment:

--- a/server.js
+++ b/server.js
@@ -1,88 +1,73 @@
 #!/usr/bin/env node
 
 /*
- * Copyright © 2017 MarkLogic Corporation
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 // clean shutdown on `ctrl + c`
 process.on('SIGINT', () => process.exit(0));
 process.on('SIGTERM', () => process.exit(0));
 
+// Following the example at https://koopjs.github.io/docs/usage/koop-core#koop-as-middleware of running Koop
+// in an existing Express server. A user can then further customize the Express server as desired.
+const express = require('express');
+const Koop = require('@koopjs/koop-core');
+
 const config = require('config');
 const log = require('./src/koop/logger');
-const fs = require('fs');
-const express = require('express');
-const http = require('http');
-const proxy = require('./src/koop/proxy');
-const Koop = require('@koopjs/koop-core');
-//Important to require dbClientManager case sensitively as "dbClientManager"
-//to get the node module cache to effectively make this be a singleton.
 const dbClientManager = require('./src/koop/dbClientManager');
+
 const koop = new Koop({});
 
-// Configure the auth plugin by executing its exported function with required args
+// Determine the authorization strategy to use; see https://koopjs.github.io/docs/usage/authorization for more info.
 if (config.auth && config.auth.enabled) {
   let auth = null;
   if (config.auth.plugin === 'auth-marklogic-digest-basic') {
     auth = require("./src/koop/authMarkLogic")(config.auth.options);
   } else if (config.auth.plugin) {
-    //if it's something we don't recognize, try to require it by plugin name and pass in the options object
-    //if this provider wants to use the static client, it will have to call dbClientManager.useStaticClient()
-    //itself in the exported function.
-    try {
-      auth = require(config.auth.plugin)(config.auth.options);
-    }
-    catch(err) {
-      throw new Error(`auth plugin ${config.auth.plugin} not recognized`);
-    }
+    auth = require(config.auth.plugin)(config.auth.options);
   }
-
   if (auth) {
+    log.info(`Using auth plugin ${config.auth.plugin}`);
     koop.register(auth);
   }
-
-  log.info(`Using auth plugin ${config.auth.plugin}`);
-
 } else {
-  //if there's no auth provider configured, we have to use a direct pre-authenticated db client
   dbClientManager.useStaticClient(true);
-
   log.info(`No auth plugin specified, relying on configured MarkLogic credentials`);
 }
-// install the Marklogic Provider
+
+// Install the Marklogic Provider after installing an authorization plugin.
 const provider = require('./src/koop');
 koop.register(provider);
 
-// create the "global" app
+// Create and configure the Express app server.
 const app = express();
-
-if (config.enableServiceProxy) {
-  // proxy requests for Geo Data Services REST extensions and v1/documents
-  app.use(/\/(v1|LATEST)/,
-    proxy.create(/\/(resources\/(modelService|geoSearchService|geoQueryService)|documents)/));
-}
-log.info(`Service proxy for geo data services is ${(config.enableServiceProxy ? 'enabled' : 'disabled')}`);
-
-// otherwise route to Koop
+const port = config.port || 8080;
 app.use('/', koop.server);
+app.listen(port);
+console.log("Koop listening on port " + port + "; press ctrl-C to exit");
 
-// create HTTP server
-const server = http.createServer(app)
-  .listen(config.port || 80);
-log.info(`Koop MarkLogic Provider listening for HTTP on ${config.port}`);
-
-// also create an HTTPS server if enabled
-if (config.ssl.enabled) {
-  const https = require('https');
-  const options = {
-    key: fs.readFileSync(config.ssl.key),
-    cert: fs.readFileSync(config.ssl.cert)
-  };
-  https.createServer(options, app)
-    .listen(config.ssl.port || 443);
-  log.info(`Koop MarkLogic Provider listening for HTTPS on ${config.ssl.port}`);
-}
-
-console.log('Press control + c to exit');
-
-module.exports = server; // make it testable
+// module.exports = server; // make it testable
+// Disabling for now, need to understand what it would be used for.
+// This may just need to go into documentation.
+// if (config.enableServiceProxy) {
+//   const proxy = require('./src/koop/proxy');
+//   // proxy requests for Geo Data Services REST extensions and v1/documents
+//   app.use(/\/(v1|LATEST)/,
+//     proxy.create(/\/(resources\/(modelService|geoSearchService|geoQueryService)|documents)/));
+// }
+// log.info(`Service proxy for geo data services is ${(config.enableServiceProxy ? 'enabled' : 'disabled')}`);
+// otherwise route to Koop
+// app.use('/', koop.server);

--- a/src/koop/marklogic.js
+++ b/src/koop/marklogic.js
@@ -15,7 +15,7 @@ const MarkLogicQuery = require('./query');
 function MarkLogic () {}
 
 MarkLogic.prototype.getData = function getData (req, callback) {
-    log.info("req.url:", req.url);
+  log.info(`Request URL: ${req.url}`);
 
     log.debug("req.params:", req.params);
     log.debug("req.query: ", req.query);


### PR DESCRIPTION
Using examples from the Koop docs for how to include our provider.

Removed SSL config; we don't need to demonstrate that, Express users will already know how to do that. 

Formatted the 3 config files, which were all a bit different. 