### PR TITLE
DEVEXP-206: Now supporting auth via a basic header

### DIFF
--- a/config/test-auth-basic-header.json
+++ b/config/test-auth-basic-header.json
@@ -1,0 +1,14 @@
+{
+  "logLevel": "debug",
+  "port": 8092,
+  "marklogic": {
+    "connection": {
+      "host": "localhost",
+      "port": 8096
+    }
+  },
+  "auth": {
+    "plugin": "auth-marklogic-basic-header",
+    "clientCacheTtlInSeconds": 10
+  }
+}

--- a/config/test-auth-ml.json
+++ b/config/test-auth-ml.json
@@ -9,7 +9,6 @@
   },
   "auth": {
     "plugin": "auth-marklogic-digest-basic",
-    "enabled": true,
     "options": {
       "secret": "7072c433-a4e7-4749-86f3-849a3ed0ee95",
       "tokenExpirationMinutes": 60

--- a/config/test-invalid-port-basic-header.json
+++ b/config/test-invalid-port-basic-header.json
@@ -1,0 +1,14 @@
+{
+  "logLevel": "debug",
+  "port": 8094,
+  "marklogic": {
+    "connection": {
+      "host": "localhost",
+      "port": 8097
+    }
+  },
+  "auth": {
+    "plugin": "auth-marklogic-basic-header",
+    "clientCacheTtlInSeconds": 10
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "start-for-tests": "NODE_ENV=test-auth-none node server.js & NODE_ENV=test-auth-ml node server.js"
+    "start-for-tests": "NODE_ENV=test-auth-none node server.js & NODE_ENV=test-auth-ml node server.js & NODE_ENV=test-auth-basic-header node server.js & NODE_ENV=test-invalid-port-basic-header node server.js",
+    "start-test-invalid-port": "NODE_ENV=test-invalid-port-basic-header node server.js"
   },
   "dependencies": {
     "config": "^3.3.9",

--- a/server.js
+++ b/server.js
@@ -32,20 +32,20 @@ const dbClientManager = require('./src/koop/dbClientManager');
 const koop = new Koop({});
 
 // Determine the authorization strategy to use; see https://koopjs.github.io/docs/usage/authorization for more info.
-if (config.auth && config.auth.enabled) {
+if (config.auth && config.auth.plugin && config.auth.enabled !== false) {
+  log.info(`Enabling auth plugin: ${config.auth.plugin}`);
   let auth = null;
   if (config.auth.plugin === 'auth-marklogic-digest-basic') {
     auth = require("./src/koop/authMarkLogic")(config.auth.options);
+  } else if (config.auth.plugin === 'auth-marklogic-basic-header') {
+    auth = require("./src/koop/authBasicHeader")();
   } else if (config.auth.plugin) {
     auth = require(config.auth.plugin)(config.auth.options);
   }
-  if (auth) {
-    log.info(`Using auth plugin ${config.auth.plugin}`);
-    koop.register(auth);
-  }
+  koop.register(auth);
 } else {
-  dbClientManager.useStaticClient(true);
   log.info(`No auth plugin specified, relying on configured MarkLogic credentials`);
+  dbClientManager.useStaticClient(true);
 }
 
 // Install the Marklogic Provider after installing an authorization plugin.

--- a/src/koop/authBasicHeader.js
+++ b/src/koop/authBasicHeader.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023 MarkLogic Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const config = require('config');
+const dbClientManager = require("./dbClientManager");
+const log = require('./logger');
+
+const clientCacheTtl = config.auth.clientCacheTtl || 3600;
+log.info(`Client cache time-to-live in seconds: ${clientCacheTtl}`);
+
+// Spec is defined at https://koopjs.github.io/docs/development/authorization
+function auth() {
+  return {
+    type: 'auth',
+    authenticationSpecification,
+    authenticate,
+    authorize
+  };
+}
+
+function authenticationSpecification() {
+  // Not clear yet based on the Koop docs what else can be defined here.
+  return {
+    useHttp: true
+  };
+}
+
+/**
+ * Function spec - https://koopjs.github.io/docs/development/authorization#authenticate-authenticatereq--promise .
+ *
+ * This seems to be used only when a client calls e.g. "/marklogic/tokens" to generate a token. For the use case for
+ * this plugin, where a client is expected to send a basic authorization header containing a username/password on each
+ * request to Koop, this function does not need to be implemented.
+ *
+ * @param req
+ * @returns {Promise<unknown>}
+ */
+function authenticate(req) {
+  return new Promise((result, reject) => {
+    const err = new Error('Token generation not supported');
+    err.code = 400;
+    reject(err);
+  });
+}
+
+function authorize(request) {
+  log.debug(`Authorizing based on basic authorization header value`);
+  return new Promise((resolve, reject) => {
+    const basicHeaderValue = _getBasicHeaderValue(request);
+    let usernameAndPassword = null;
+    if (basicHeaderValue != null) {
+      usernameAndPassword = _getUsernameAndPassword(basicHeaderValue);
+    }
+    if (usernameAndPassword === null) {
+      const err = new Error("Unauthorized");
+      err.code = 401;
+      reject(err);
+    }
+
+    const clientCacheKey = basicHeaderValue;
+    const existingClient = dbClientManager.getCachedMarkLogicClient(clientCacheKey);
+
+    if (existingClient !== undefined) {
+      request.markLogicClientCacheKey = clientCacheKey;
+      resolve({});
+    } else {
+      const username = usernameAndPassword[0];
+      const password = usernameAndPassword[1];
+      dbClientManager.connectAndCacheClient(username, password, clientCacheTtl, clientCacheKey).then(response => {
+        if (response.authenticated) {
+          request.markLogicClientCacheKey = clientCacheKey;
+          resolve({});
+        } else {
+          // Per https://koopjs.github.io/docs/development/authorization#authorize-function-authorizereq--promise,
+          // a 401 should be returned here, though Koop will turn that into a 200 with the response body containing a
+          // JSON object that defines the error.
+          const err = new Error(response.httpStatusMessage);
+          err.code = 401;
+          reject(err);
+        }
+      }).catch(error => {
+        // No need to log, Koop will log this automatically at the "error" level.
+        reject(error);
+      });
+    }
+  });
+}
+
+function _getBasicHeaderValue(request) {
+  // QGIS uses 'authorization', but it's commonly 'Authorization' as well.
+  const basicHeader = request.headers['Authorization'] || request.headers['authorization'];
+  return basicHeader && basicHeader.startsWith('Basic ') ? basicHeader.substring(6) : null;
+}
+
+function _getUsernameAndPassword(basicHeaderValue) {
+  const decoded = Buffer.from(basicHeaderValue, "base64").toString("utf-8");
+  const usernameAndPassword = decoded.split(":");
+  if (usernameAndPassword.length == 2) {
+    return usernameAndPassword;
+  }
+  return null;
+}
+
+module.exports = auth;

--- a/src/koop/dbClientManager.js
+++ b/src/koop/dbClientManager.js
@@ -6,105 +6,88 @@
 */
 const config = require('config');
 const marklogic = require('marklogic');
-const http = require('http');
 const Agent = require('yakaa');
 const log = require('./logger');
 const NodeCache = require( "node-cache" );
 
-let _dbClientCache = new NodeCache({useClones:false});
+let _clientCache = new NodeCache({useClones:false});
+// "static" = a single client for all users to use for connecting to MarkLogic.
 let _staticClient = null;
 let _keepAliveAgent = new Agent({ keepAlive: true });
 let _useStaticClient = false;
 
-const dbc = {
-        getDBClient,
-        useStaticClient,
-        connectClient
-    };
-
-function getDBClient(username) {
-
-    if (config.auth == null || _useStaticClient) {
-        log.debug("getting static db client");
-        if (_staticClient == null) {
-            log.debug("creating static dbClient");
-            let connectionParams = JSON.parse(JSON.stringify(config.marklogic.connection));
-            connectionParams.agent = _keepAliveAgent;
-             _staticClient = marklogic.createDatabaseClient(connectionParams);
-        }
-        return _staticClient;
+/**
+ * The marklogic.js module uses this to obtain a client instance, which is expected to have been configured via an
+ * authorization plugin. Or if no plugin was configured, then the "static" client is returned.
+ *
+ * @param clientCacheKey
+ * @returns {DatabaseClient|unknown}
+ */
+function getCachedMarkLogicClient(clientCacheKey) {
+  if (config.auth == null || _useStaticClient) {
+    if (_staticClient == null) {
+      log.info("Creating single MarkLogic client for all users to use");
+      let connectionParams = JSON.parse(JSON.stringify(config.marklogic.connection));
+      connectionParams.agent = _keepAliveAgent;
+      _staticClient = marklogic.createDatabaseClient(connectionParams);
     }
-    log.debug("getting dbClient for username " + username);
-    return _dbClientCache.get(username);
+    return _staticClient;
+  }
+  return _clientCache.get(clientCacheKey);
 }
 
 function useStaticClient(staticClientEnabled) {
-    if (staticClientEnabled == true) {
-        _useStaticClient = true;
-    } else {
-        _useStaticClient = false;
-    }
+  _useStaticClient = staticClientEnabled;
 }
 
-function checkDbClientConnection(db, username) {
-    let connectionInfo = {};
-    return new Promise((resolve, reject) => {
-        db.checkConnection().result(function(response) {
-            log.debug("db.checkConnection result:");
-            log.debug(response);
-            if (response.connected) {
-                log.debug("response is connected");
-                connectionInfo.authenticated = true;
-                log.debug("setting db client in cache...");
-                _dbClientCache.set(username, db);
-                resolve(connectionInfo);
+/**
+ * Expected to be used by authorization plugins to create a client and connect to MarkLogic, and if done successfully,
+ * cache the client as well so that marklogic.js can access it via an authorization-specific cache key.
+ *
+ * As expected from the signature, only supports basic/digest authentication today since username/password are required.
+ *
+ * @param username
+ * @param password
+ * @param ttlInSeconds
+ * @param clientCacheKey
+ * @returns {Promise<unknown>}
+ */
+function connectAndCacheClient(username, password, ttlInSeconds=0, clientCacheKey=username) {
+  const connectionParams = JSON.parse(JSON.stringify(config.marklogic.connection));
+  connectionParams.user = username;
+  connectionParams.password = password;
+  connectionParams.agent = _keepAliveAgent;
+
+  const client = marklogic.createDatabaseClient(connectionParams);
+  return new Promise((resolve, reject) => {
+    client
+      .checkConnection()
+      .result(
+        function (response) {
+          log.debug(`checkConnection response: ${JSON.stringify(response)}`);
+          if (response.connected) {
+            if (ttlInSeconds > 0) {
+              _clientCache.set(clientCacheKey, client, ttlInSeconds);
+            } else {
+              _clientCache.set(clientCacheKey, client);
             }
-            else {
-                log.debug("response is not connected");
-                connectionInfo.authenticated = false;
-                connectionInfo.httpStatusMessage = response.httpStatusMessage;
-                connectionInfo.httpStatusCode = response.httpStatusCode;
-                log.debug("clearing db client from cache...");
-                _dbClientCache.del(username);
-                log.debug("resolving connectionInfo:");
-                log.debug(connectionInfo);
-                resolve(connectionInfo);
-            }
-        },
-        function(error) {
-            log.debug("error occurred:");
-            log.error(error);
-            connectionInfo.error = true;
-            connectionInfo.errorMsg = error.message;
-            _dbClientCache.del(username);
-            log.debug("resolving connection error connectionInfo:");
-            log.debug(connectionInfo);
-            resolve(connectionInfo);
-        }).catch(error => {
-            log.error(error);
-            //throw new Error("Error connecting client");
-            log.debug("rejecting connectionInfo:");
-            log.debug(connectionInfo);
-            reject(connectionInfo);
-        })
-    });
+            resolve({"authenticated": true});
+          } else {
+            _clientCache.del(clientCacheKey);
+            resolve({"authenticated": false, "httpStatusMessage": response.httpStatusMessage});
+          }
+        }
+      )
+      .catch(error => {
+        // Add a message for context; the error already contains the message from the MarkLogic client.
+        error.message = `Received error while connecting as user ${username}`;
+        reject(error);
+      });
+  });
 }
 
-function connectClient(username, password) {
-    //we make a deep copy of the connection params so we don't leak 
-    //usernames/passwords across requests and so we can specify the
-    //agent.  Setting the agent to the global agent makes the
-    //marklogic.createDatabaseClient() call as well as the database client
-    //itself both lightweight 
-    let connectionParams = JSON.parse(JSON.stringify(config.marklogic.connection));
-    connectionParams.user = username;
-    connectionParams.password = password;
-    connectionParams.agent = _keepAliveAgent;
-
-    log.debug("creating dbClient...");
-    let db = marklogic.createDatabaseClient(connectionParams);
-    log.debug (db)
-    return checkDbClientConnection(db,username);
-}
-
-module.exports=dbc;
+module.exports={
+  connectAndCacheClient,
+  getCachedMarkLogicClient,
+  useStaticClient
+};

--- a/src/koop/marklogic.js
+++ b/src/koop/marklogic.js
@@ -54,7 +54,9 @@ MarkLogic.prototype.getData = function getData (req, callback) {
     query: req.query
   }
 
-    const dbClient = dbClientManager.getDBClient(req.marklogicUsername);
+  // The authentication plugin is expected to populate this parameter on the request to identify how a cached
+  // MarkLogic client object should be obtained for this particular request.
+  const dbClient = dbClientManager.getCachedMarkLogicClient(req.markLogicClientCacheKey);
 
 	  new MarkLogicQuery().providerGetData(providerRequest, dbClient)
 	    .then(data => {

--- a/test/src/test/java/BasicAuthHeaderTest.java
+++ b/test/src/test/java/BasicAuthHeaderTest.java
@@ -1,0 +1,89 @@
+import io.restassured.RestAssured;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Verifies the "auth-marklogic-basic-header" authorization plugin.
+ */
+public class BasicAuthHeaderTest extends AbstractFeatureServiceTest {
+
+    @Before
+    public void connectToBasicHeaderKoop() {
+        RestAssured.port = 8092;
+        RestAssured.baseURI = "http://localhost";
+    }
+
+    @Test
+    public void validUsernameAndPassword() {
+        new RestAssuredHelper()
+            .withBasicHeader("test-geo-data-services-writer", "test-geo-data-services-writer")
+            .get(request2path("featureService.json"))
+            // Just make sure at least one field is correct, that's good enough to verify that we logged in successfully.
+            .body("currentVersion", is(10.51f));
+    }
+
+    @Test
+    public void invalidUsernameAndPassword() {
+        new RestAssuredHelper().withBasicHeader("bad", "login")
+            .get(request2path("featureService.json"), 200)
+            // While https://koopjs.github.io/docs/development/authorization#authorize-function-authorizereq--promise
+            // states that the 'authorize' function in a plugin should return a 401, Koop seems to then convert this
+            // into a 200 and instead included the error in the response body. And that error always has a message of
+            // "Token Required", even though that's not really appropriate here.
+            .body("error.code", is(499))
+            .body("error.message", is("Token Required"));
+    }
+
+    @Test
+    public void noHeaderFound() {
+        new RestAssuredHelper()
+            .get(request2path("featureService.json"), 200)
+            .body("error.code", is(499))
+            .body("error.message", is("Token Required"));
+    }
+
+    @Test
+    public void invokeTokensEndpoint() {
+        new RestAssuredHelper()
+            // It appears that if an auth plugin returns an error with a code other than 401, then that error will be
+            // returned to the client. A 400 is expected here since the "authenticate" function is not expected to
+            // work for this plugin since it does not support generating tokens.
+            .get("/marklogic/tokens?username=test-geo-data-services-writer&password=test-geo-data-services-writer", 400)
+            .body("error", is("Token generation not supported"));
+    }
+
+    /**
+     * Intent of this test is to make sure that a MarkLogic client instance isn't cached and reused when the user
+     * submits a request with the same username but an invalid password.
+     */
+    @Test
+    public void validPasswordAndThenInvalidPassword() {
+        final String user = "test-geo-data-services-writer";
+        final String validPassword = "test-geo-data-services-writer";
+        final String invalidPassword = "bad";
+
+        new RestAssuredHelper()
+            .withBasicHeader(user, validPassword)
+            .get(request2path("featureService.json"))
+            .body("currentVersion", is(10.51f));
+
+        new RestAssuredHelper()
+            .withBasicHeader(user, invalidPassword)
+            .get(request2path("featureService.json"))
+            .body("error.code", is(499))
+            .body("error.message", is("Token Required"));
+    }
+
+    @Test
+    public void invalidMarkLogicPort() {
+        RestAssured.port = 8094;
+        new RestAssuredHelper()
+            .withBasicHeader("test-geo-data-services-writer", "test-geo-data-services-writer")
+            .get(request2path("featureService.json"), 500)
+            // When a 500 is returned by a Koop provider, the Koop server will always have an error message of
+            // "Internal Server Error".
+            .body("error", is("Internal Server Error"));
+    }
+}

--- a/test/src/test/java/RestAssuredHelper.java
+++ b/test/src/test/java/RestAssuredHelper.java
@@ -1,6 +1,7 @@
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
+import org.apache.commons.codec.binary.Base64;
 
 /**
  * This is a "helper" currently for removing a bunch of duplication across hundreds of tests - the duplicated code is
@@ -12,6 +13,21 @@ public class RestAssuredHelper {
 
     public RestAssuredHelper() {
         spec = RestAssured.given();
+    }
+
+    public RestAssuredHelper(RequestSpecification spec) {
+        this.spec = spec;
+    }
+
+    public RestAssuredHelper withBasicHeader(String username, String password) {
+        spec.header("authorization", buildBasicHeader(username, password));
+        return this;
+    }
+
+    private String buildBasicHeader(String username, String password) {
+        String str = username + ":" + password;
+        String encoded = new String(Base64.encodeBase64(str.getBytes()));
+        return "Basic " + encoded;
     }
 
     public RequestSpecification pathParam(String name, Object value) {


### PR DESCRIPTION
Did a fair amount of cleanup in dbClientManager to hopefully make it easier to understand and read. 

One key rename is from "req.marklogicUsername" to "req.markLogicClientCacheKey" to make it clear that the purpose of this value is for retrieving a client instance from the cache maintained by dbClientManager. 

Added two more configs - one for testing basic auth, and one for testing what happens with basic with when there's an invalid port. 