### PR TITLE
DEVEXP-206: Now supporting auth via a basic header

### DIFF
--- a/src/koop/marklogic.js
+++ b/src/koop/marklogic.js
@@ -58,6 +58,9 @@ MarkLogic.prototype.getData = function getData (req, callback) {
 
 	  new MarkLogicQuery().providerGetData(providerRequest, dbClient)
 	    .then(data => {
+        if (req.query.skipFiltering === true) {
+          data.filtersApplied.all = true;
+        }
 	      callback(null, data);
       })
       .catch(function(error) {


### PR DESCRIPTION
I found that setting "data.filtersApplied.all = true", after the data has been retrieved from MarkLogic, prevents the filtering from happening (which prevents the null values from being ordered incorrectly).

However, setting that value all the time causes quite a few tests to fail. Additionally, it's conceivable that it would change current behavior that users don't want changed.

So, I propose a new query param, "skipFiltering". When that param is set to true, then data.filtersApplied.all is set to true, and the filtering step is skipped and the null values are sorted as expected.

Thoughts?